### PR TITLE
Fix ROS 1 build

### DIFF
--- a/include/sick_scan/sick_ros_wrapper.h
+++ b/include/sick_scan/sick_ros_wrapper.h
@@ -410,7 +410,7 @@ namespace sick_scan
 /*
 ** ROS-2 requires lowercase field names in all idl generated message structs
 */
-#if __ROS_VERSION > 0
+#if __ROS_VERSION > 1
 #define radarPreHeader radarpreheader
 #define uiVersionNo uiversionno
 #define radarPreHeaderDeviceBlock radarpreheaderdeviceblock

--- a/package.xml
+++ b/package.xml
@@ -43,6 +43,7 @@
   <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
 
   <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
     <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
   </export>
   


### PR DESCRIPTION
catkin_make was refusing to build this package because it couldn't identify the build type, so this explicitly sets the build_type to
catkin when in a ROS 1 environment.

Also, there was a header that was defining some values that should only be set in ROS 2, and the #if definition around it was accidentally checking if the ROS version was >0 rather than >1, so this also fixes that.

Signed-off-by: P. J. Reed <phillipreed@hatchbed.com>