### PR TITLE
Fix command-line parsing in ROS2.

### DIFF
--- a/driver/src/sick_generic_laser.cpp
+++ b/driver/src/sick_generic_laser.cpp
@@ -212,6 +212,12 @@ bool parseLaunchfileSetParameter(rosNodePtr nhPriv, int argc, char **argv)
   for (int n = 1; n < argc; n++)
   {
     std::string argv_str = argv[n];
+
+    // Ignore all arguments after and including --ros-args
+    if (argv_str == "--ros-args") {
+      break;
+    }
+
     if (getTagVal(argv_str, tag, val))
     {
         rosSetParam(nhPriv, tag, val);


### PR DESCRIPTION
This addition forces the command-line parser to ignore all arguments after and including `--ros-args` which is used to supply parameters and remapping rules to a node in ROS2 Eloquent and above. This should not affect ROS1 or non-ROS environments because the argument `--ros-args` is unique to ROS2.

Tested with multiple TIMs lidars in a single launch file. As a side bonus, ROS2 now respects and applies the parameters after `--ros-args` as well.