### PR TITLE
Inconsistent use of "MRS" and "TIM" in example urdf

### DIFF
--- a/urdf/example.urdf.xacro
+++ b/urdf/example.urdf.xacro
@@ -8,6 +8,6 @@
   <xacro:include filename="$(find sick_scan)/urdf/sick_scan.urdf.xacro" />
 
   <xacro:sick_tim_5xx name="laser" ros_topic="scan" />
-  <xacro:sick_mrs_1xxx name="laser" ros_topic="scan" />
+  <xacro:sick_tim_1xxx name="laser" ros_topic="scan" />
 </robot>
 

--- a/urdf/sick_scan.urdf.xacro
+++ b/urdf/sick_scan.urdf.xacro
@@ -28,12 +28,12 @@
       mesh="package://sick_scan/meshes/sick_tim_5xx.stl" />
   </xacro:macro>
 
-  <xacro:macro name="sick_mrs_1xxx" params="name ros_topic min_angle:=-2.357 max_angle:=2.357 gaussian_noise:=0.015 samples:=271">
+  <xacro:macro name="sick_tim_1xxx" params="name ros_topic min_angle:=-2.357 max_angle:=2.357 gaussian_noise:=0.015 samples:=271">
     <xacro:sick_tim name="${name}" ros_topic="${ros_topic}"
       length="0.06" width="0.06" height="0.079" mass="0.150" z_offset="0.05595"
       min_angle="${min_angle}" max_angle="${max_angle}"
       min_range="0.05" max_range="4.0" gaussian_noise="${gaussian_noise}" samples="${samples}"
-      mesh="package://sick_scan/meshes/sick_tim_5xx.stl" />
+      mesh="package://sick_scan/meshes/sick_tim_1xxx.stl" />
   </xacro:macro>
 
   <xacro:macro name="sick_tim" params="name ros_topic length width height mass z_offset min_angle max_angle min_range max_range gaussian_noise samples mesh">


### PR DESCRIPTION
This PR makes the `example.urdf.xacro` consistently use the `tim` meshes/names of the lidar.

## issue
The current example `urdf` defines a macro [`sick_mrs_1xxx`](https://github.com/SICKAG/sick_scan_xd/blob/d8e827ab7bf747f3b48901e81da99104cf77dc71/urdf/sick_scan.urdf.xacro#L31) that uses a [`tim`-mesh](https://github.com/SICKAG/sick_scan_xd/blob/d8e827ab7bf747f3b48901e81da99104cf77dc71/urdf/sick_scan.urdf.xacro#L36) then uses the macro [`sick_tim`](https://github.com/SICKAG/sick_scan_xd/blob/d8e827ab7bf747f3b48901e81da99104cf77dc71/urdf/sick_scan.urdf.xacro#L32).

I assume this is not intended as the link within the [lidar](https://github.com/SICKAG/sick_scan_xd/blob/d8e827ab7bf747f3b48901e81da99104cf77dc71/urdf/sick_scan.urdf.xacro#L32) probably differs between the MRS and the TIM?

## solution
This PR updates the `example.urdf.xacro` so that it only refers to the name and meshes of the TIM models.