### PR TITLE
Timestamp Laserscan message corrected #47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ features that will be removed in future versions **Removed** for deprecated feat
 
 ## Released ##
 
+### v2.6.3 - 
+  - **Fixed** Timestamp Laserscan message corrected
+
 ### v2.6.2 - 
   - **Fixed** LDMRS spinning problem corrected
 

--- a/driver/src/sick_generic_caller.cpp
+++ b/driver/src/sick_generic_caller.cpp
@@ -81,7 +81,7 @@
 
 #define SICK_GENERIC_MAJOR_VER "2"
 #define SICK_GENERIC_MINOR_VER "6"
-#define SICK_GENERIC_PATCH_LEVEL "2"
+#define SICK_GENERIC_PATCH_LEVEL "3"
 
 #include <algorithm> // for std::min
 

--- a/driver/src/sick_scan_common.cpp
+++ b/driver/src/sick_scan_common.cpp
@@ -3785,7 +3785,7 @@ namespace sick_scan
         bool FireEncoder = false;
         EncoderMsg.header.frame_id = "Encoder";
         ROS_HEADER_SEQ(EncoderMsg.header, numPacketsProcessed);
-        msg.header.stamp = recvTimeStamp + rosDuration(config_.time_offset);
+        msg.header.stamp = recvTimeStamp + rosDuration(config_.time_offset); // default: ros-timestamp at message received, will be updated by software-pll
         double elevationAngleInRad = 0.0;
         short elevAngleX200 = 0;  // signed short (F5 B2  -> Layer 24
         // F5B2h -> -2638/200= -13.19°
@@ -3940,6 +3940,10 @@ namespace sick_scan
                       dataToProcess = false;
                       break;
                     }
+                    else
+                    {
+                      msg.header.stamp = recvTimeStamp + rosDuration(config_.time_offset); // update timestamp by software-pll
+					}
                   }
 
 #ifdef DEBUG_DUMP_ENABLED


### PR DESCRIPTION
Timestamp of pointcloud and laserscan messages identical and computed from lidar ticks by software-pll