### PR TITLE
LRS4xxx scan configuration #52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ features that will be removed in future versions **Removed** for deprecated feat
 
 ## Released ##
 
+### v2.6.5 - 
+  - **Fixed** LRS4xxx scan configuration #52
+
 ### v2.6.4 - 
   - **Fixed** LMS5xx echo filter settings corrected
 

--- a/cfg/SickScan.cfg
+++ b/cfg/SickScan.cfg
@@ -94,7 +94,7 @@ gen.add("cloud_output_mode", int_t, 0, "[0] Pointcloud is dense all layers in on
 gen.add("ang_res",      double_t, 0, "Angular resolution in deg/scan set to 0 to use scanner default",  0 ,0,10)
 gen.add("scan_freq",    double_t, 0, "Scan frequency set to 0 to use scanner default",0 ,0,100)
 gen.add("encoder_mode", int_t, 0, "-1:No Encoder, 0:Off, 1:Single increment, 2:Direction Phase, 3:Direction Level",-1 ,-1,3)
-gen.add("scan_cfg_list_entry",  int_t, 0, "scan config for | LRS 3601 3611 |OEM 1501|NAV 310 |LRS 3600 3610 |OEM 1500|",-1 ,1,46)
+gen.add("scan_cfg_list_entry",  int_t, 0, "scan config for | LRS 3601 3611 |OEM 1501|NAV 310 |LRS 3600 3610 4000 |OEM 1500|",-1 ,1,71) # LD Series switching table: 1-46, LRS4000 switching table: 1-71
 # gen.add("mean_filter", int_t,  0, "Number of averages for mean filter 0 means filter is disabled", 0, 0, 100)
 # gen.add("mirror_scan",bool_t, 0, "Scan direction's changed. E.g. for overhead mounting or NAV 310 ( in contrast to other sick scanners NAV 310 is clockwise rotating ).",False)
 # gen.add("use_safety_fields",    bool_t,   0, "Whether or not to use safety fields. Only tim 7xxS supported at the moment", False) # True)

--- a/driver/src/sick_generic_caller.cpp
+++ b/driver/src/sick_generic_caller.cpp
@@ -81,7 +81,7 @@
 
 #define SICK_GENERIC_MAJOR_VER "2"
 #define SICK_GENERIC_MINOR_VER "6"
-#define SICK_GENERIC_PATCH_LEVEL "4"
+#define SICK_GENERIC_PATCH_LEVEL "5"
 
 #include <algorithm> // for std::min
 

--- a/driver/src/sick_generic_parser.cpp
+++ b/driver/src/sick_generic_parser.cpp
@@ -394,6 +394,16 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
     return this->useScancfgList;
   }
 
+  void ScannerBasicParam::setUseWriteOutputRanges(bool _useWriteOutputRanges)
+  {
+      this->useWriteOutputRanges = _useWriteOutputRanges;
+  }
+
+  bool ScannerBasicParam::getUseWriteOutputRanges()
+  {
+      return this->useWriteOutputRanges;
+  }
+
   void ScannerBasicParam::setWaitForReady(bool _waitForReady)
   {
     this->waitForReady = _waitForReady;
@@ -421,7 +431,8 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
   : numberOfLayers(0), numberOfShots(0), numberOfMaximumEchos(0), elevationDegreeResolution(0), angleDegressResolution(0), expectedFrequency(0),
      useBinaryProtocol(false), IntensityResolutionIs16Bit(false), deviceIsRadar(false), useSafetyPasWD(false), encoderMode(0),
      CartographerCompatibility(false), scanMirroredAndShifted(false), useEvalFields(EVAL_FIELD_UNSUPPORTED), maxEvalFields(0),
-     imuEnabled (false), scanAngleShift(0)
+     imuEnabled (false), scanAngleShift(0), useScancfgList(false), useWriteOutputRanges(false)
+
   {
     this->elevationDegreeResolution = 0.0;
     this->setUseBinaryProtocol(false);
@@ -517,6 +528,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(EVAL_FIELD_UNSUPPORTED);
         basicParams[i].setMaxEvalFields(0);
         basicParams[i].setUseScancfgList(false);
+        basicParams[i].setUseWriteOutputRanges(true); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(true);
         basicParams[i].setFREchoFilterAvailable(true);
       }
@@ -540,6 +552,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(EVAL_FIELD_UNSUPPORTED);
         basicParams[i].setMaxEvalFields(0);
         basicParams[i].setUseScancfgList(false);
+        basicParams[i].setUseWriteOutputRanges(true); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(true);
         basicParams[i].setFREchoFilterAvailable(false);
       }
@@ -562,6 +575,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(EVAL_FIELD_UNSUPPORTED);
         basicParams[i].setMaxEvalFields(0);
         basicParams[i].setUseScancfgList(false);
+        basicParams[i].setUseWriteOutputRanges(true); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(false);
         basicParams[i].setFREchoFilterAvailable(false);
       }
@@ -584,6 +598,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(EVAL_FIELD_UNSUPPORTED);
         basicParams[i].setMaxEvalFields(0);
         basicParams[i].setUseScancfgList(false);
+        basicParams[i].setUseWriteOutputRanges(true); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(false);
         basicParams[i].setFREchoFilterAvailable(false);
       }
@@ -605,6 +620,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(EVAL_FIELD_UNSUPPORTED);
         basicParams[i].setMaxEvalFields(0);
         basicParams[i].setUseScancfgList(false);
+        basicParams[i].setUseWriteOutputRanges(true); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(false);
         basicParams[i].setFREchoFilterAvailable(false);
       }
@@ -626,6 +642,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(USE_EVAL_FIELD_TIM7XX_LOGIC);
         basicParams[i].setMaxEvalFields(48);
         basicParams[i].setUseScancfgList(false);
+        basicParams[i].setUseWriteOutputRanges(true); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(false);
         basicParams[i].setFREchoFilterAvailable(false);
       }
@@ -647,6 +664,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(USE_EVAL_FIELD_TIM7XX_LOGIC);
         basicParams[i].setMaxEvalFields(48);
         basicParams[i].setUseScancfgList(false);
+        basicParams[i].setUseWriteOutputRanges(true); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(false);
         basicParams[i].setFREchoFilterAvailable(false);
       }
@@ -668,6 +686,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(USE_EVAL_FIELD_LMS5XX_LOGIC);
         basicParams[i].setMaxEvalFields(30);
         basicParams[i].setUseScancfgList(false);
+        basicParams[i].setUseWriteOutputRanges(true); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(false);
         basicParams[i].setFREchoFilterAvailable(true); // (false) // LMS uses echo filter settings to configure number of echos: "sWN FREchoFilter N" with N=0: first echo, N=1: all echos, N=2: last echo
       }
@@ -689,6 +708,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(USE_EVAL_FIELD_LMS5XX_LOGIC);
         basicParams[i].setMaxEvalFields(30);
         basicParams[i].setUseScancfgList(false);
+        basicParams[i].setUseWriteOutputRanges(true); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(true); // changed from false to true, see comment in sick_lms1xx.launch
         basicParams[i].setFREchoFilterAvailable(false);
       }
@@ -710,6 +730,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(EVAL_FIELD_UNSUPPORTED);// TODO Check this
         basicParams[i].setMaxEvalFields(30);
         basicParams[i].setUseScancfgList(true);
+        basicParams[i].setUseWriteOutputRanges(false); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(true);
         basicParams[i].setFREchoFilterAvailable(false);
       }
@@ -731,6 +752,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(EVAL_FIELD_UNSUPPORTED);// TODO Check this
         basicParams[i].setMaxEvalFields(30);
         basicParams[i].setUseScancfgList(true);
+        basicParams[i].setUseWriteOutputRanges(false); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(true);
         basicParams[i].setFREchoFilterAvailable(false);
       }
@@ -753,12 +775,13 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(EVAL_FIELD_UNSUPPORTED);
         basicParams[i].setMaxEvalFields(0);
         basicParams[i].setUseScancfgList(false);
+        basicParams[i].setUseWriteOutputRanges(true); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(false);
         basicParams[i].setFREchoFilterAvailable(true);
       }
-      if (basicParams[i].getScannerName().compare(SICK_SCANNER_LRS_4XXX_NAME) == 0) // LMS_5xx - 1 Layer
+      if (basicParams[i].getScannerName().compare(SICK_SCANNER_LRS_4XXX_NAME) == 0) // LRS_4XXX - 1 Layer
       {
-        basicParams[i].setNumberOfMaximumEchos(1);// TODO validate this
+        basicParams[i].setNumberOfMaximumEchos(1);
         basicParams[i].setNumberOfLayers(1);
         basicParams[i].setNumberOfShots(7201);
         basicParams[i].setAngularDegreeResolution(0.05);
@@ -773,9 +796,10 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setScanMirroredAndShifted(false);
         basicParams[i].setUseEvalFields(EVAL_FIELD_UNSUPPORTED);
         basicParams[i].setMaxEvalFields(0);
-        basicParams[i].setUseScancfgList(false);
+        basicParams[i].setUseScancfgList(true); // false // LRS4000 sets scan rate and angular resolution set by "sMN mCLsetscancfglist <mode>"
+        basicParams[i].setUseWriteOutputRanges(true); // false // LRS4000 sets the scan configuration by both "sMN mCLsetscancfglist <mode>" AND "sWN LMPoutputRange" (default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry)
         basicParams[i].setWaitForReady(false);
-        basicParams[i].setFREchoFilterAvailable(false);
+        basicParams[i].setFREchoFilterAvailable(true); // (false) // LRS4XXX uses echo filter settings to configure 1 echo, use filter_echos = 0 (first echo) for LRS4xxx
       }
       if (basicParams[i].getScannerName().compare(SICK_SCANNER_RMS_3XX_NAME) == 0) // Radar
       {
@@ -796,6 +820,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(EVAL_FIELD_UNSUPPORTED);
         basicParams[i].setMaxEvalFields(0);
         basicParams[i].setUseScancfgList(false);
+        basicParams[i].setUseWriteOutputRanges(true); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(false);
         basicParams[i].setFREchoFilterAvailable(false);
       }
@@ -818,6 +843,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(EVAL_FIELD_UNSUPPORTED);
         basicParams[i].setMaxEvalFields(0);
         basicParams[i].setUseScancfgList(false);
+        basicParams[i].setUseWriteOutputRanges(true); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(false);
         basicParams[i].setFREchoFilterAvailable(false);
       }
@@ -839,6 +865,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(EVAL_FIELD_UNSUPPORTED);
         basicParams[i].setMaxEvalFields(0);
         basicParams[i].setUseScancfgList(true);
+        basicParams[i].setUseWriteOutputRanges(false); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(true);
         basicParams[i].setFREchoFilterAvailable(false);
       }
@@ -860,6 +887,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(EVAL_FIELD_UNSUPPORTED);
         basicParams[i].setMaxEvalFields(0);
         basicParams[i].setUseScancfgList(true);
+        basicParams[i].setUseWriteOutputRanges(false); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(true);
         basicParams[i].setFREchoFilterAvailable(false);
       }
@@ -881,6 +909,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(EVAL_FIELD_UNSUPPORTED);
         basicParams[i].setMaxEvalFields(0);
         basicParams[i].setUseScancfgList(false);
+        basicParams[i].setUseWriteOutputRanges(true); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(false);
         basicParams[i].setFREchoFilterAvailable(false);
       }
@@ -902,6 +931,7 @@ void ScannerBasicParam::setTrackingModeSupported(bool _trackingModeSupported)
         basicParams[i].setUseEvalFields(EVAL_FIELD_UNSUPPORTED);
         basicParams[i].setMaxEvalFields(0);
         basicParams[i].setUseScancfgList(false);
+        basicParams[i].setUseWriteOutputRanges(true); // default: use "sWN LMPoutputRange" if scan configuration not set by ScanCfgList-entry
         basicParams[i].setWaitForReady(false);
         basicParams[i].setFREchoFilterAvailable(false);
       }

--- a/driver/src/sick_scan_common.cpp
+++ b/driver/src/sick_scan_common.cpp
@@ -1557,6 +1557,7 @@ namespace sick_scan
     rosGetParam(nh, "intensity", rssiFlag);
     rosDeclareParam(nh, "intensity_resolution_16bit", rssiResolutionIs16Bit);
     rosGetParam(nh, "intensity_resolution_16bit", rssiResolutionIs16Bit);
+    // rosDeclareParam(nh, "min_intensity", m_min_intensity);
     rosGetParam(nh, "min_intensity", m_min_intensity); // Set range of LaserScan messages to infinity, if intensity < min_intensity (default: 0)
     //check new ip adress and add cmds to write ip to comand chain
     std::string sNewIPAddr = "";
@@ -1881,7 +1882,7 @@ namespace sick_scan
             {
               return ExitFatal;
             }
-//					ROS_ERROR("BINARY REPLY REQUIRED");
+//                  ROS_ERROR("BINARY REPLY REQUIRED");
           }
           else
           {
@@ -2132,6 +2133,7 @@ namespace sick_scan
           // Here we get the reply to "sRN LMPscancfg". We use this reply to set the scan configuration (frequency, start and stop angle)
           // for the following "sMN mCLsetscancfglist" and "sMN mLMPsetscancfg ..." commands
           int cfgListEntry = 1;
+          // rosDeclareParam(nh, "scan_cfg_list_entry", cfgListEntry);
           rosGetParam(nh, "scan_cfg_list_entry", cfgListEntry);
           sopasCmdVec[CMD_SET_SCAN_CFG_LIST] = "\x02sMN mCLsetscancfglist " + std::to_string(cfgListEntry) + "\x03"; // set scan config from list for NAX310  LD - OEM15xx LD - LRS36xx
           sopasCmdVec[CMD_SET_SCANDATACONFIGNAV] = ""; // set start and stop angle by LMPscancfgToSopas()
@@ -2269,8 +2271,8 @@ namespace sick_scan
         {
           // scanconfig handling with list
           char requestsMNmCLsetscancfglist[MAX_STR_LEN];
-          int cfgListEntry;
-          //rosDeclareParam(nh, "scan_cfg_list_entry", cfgListEntry);
+          int cfgListEntry = 1;
+          // rosDeclareParam(nh, "scan_cfg_list_entry", cfgListEntry);
           rosGetParam(nh, "scan_cfg_list_entry", cfgListEntry);
           // Uses sprintf-Mask to set bitencoded echos and rssi enable flag
           const char *pcCmdMask = sopasCmdMaskVec[CMD_SET_SCAN_CFG_LIST].c_str();
@@ -2293,7 +2295,7 @@ namespace sick_scan
           }
         }
       }
-      else // CMD_GET_OUTPUT_RANGE (i.e. handling of LMDscandatacfg
+      if (this->parser_->getCurrentParamPtr()->getUseWriteOutputRanges()) // else // CMD_GET_OUTPUT_RANGE
       {
         if (useBinaryCmd)
         {
@@ -2371,34 +2373,34 @@ namespace sick_scan
           }
         }
 
-      //-----------------------------------------------------------------
-      //
-      // Set Min- und Max scanning angle given by config
-      //
-      //-----------------------------------------------------------------
+		//-----------------------------------------------------------------
+		//
+		// Set Min- und Max scanning angle given by config
+		//
+		//-----------------------------------------------------------------
 
-      ROS_INFO_STREAM("MIN_ANG: " << config_.min_ang << " [rad] " << rad2deg(this->config_.min_ang) << " [deg]");
-      ROS_INFO_STREAM("MAX_ANG: " << config_.max_ang << " [rad] " << rad2deg(this->config_.max_ang) << " [deg]");
+		ROS_INFO_STREAM("MIN_ANG: " << config_.min_ang << " [rad] " << rad2deg(this->config_.min_ang) << " [deg]");
+		ROS_INFO_STREAM("MAX_ANG: " << config_.max_ang << " [rad] " << rad2deg(this->config_.max_ang) << " [deg]");
 
-      // convert to 10000th degree
-      double minAngSopas = rad2deg(this->config_.min_ang);
-      double maxAngSopas = rad2deg(this->config_.max_ang);
+		// convert to 10000th degree
+		double minAngSopas = rad2deg(this->config_.min_ang);
+		double maxAngSopas = rad2deg(this->config_.max_ang);
 
-      minAngSopas -= rad2deg(this->parser_->getCurrentParamPtr()->getScanAngleShift());
-      maxAngSopas -= rad2deg(this->parser_->getCurrentParamPtr()->getScanAngleShift());
-      // if (this->parser_->getCurrentParamPtr()->getScannerName().compare(SICK_SCANNER_TIM_240_NAME) == 0)
-      // {
-      //   // the TiM240 operates directly in the ros coordinate system
-      // }
-      // else
-      // {
-      //   minAngSopas += 90.0;
-      //   maxAngSopas += 90.0;
-      // }
+		minAngSopas -= rad2deg(this->parser_->getCurrentParamPtr()->getScanAngleShift());
+		maxAngSopas -= rad2deg(this->parser_->getCurrentParamPtr()->getScanAngleShift());
+		// if (this->parser_->getCurrentParamPtr()->getScannerName().compare(SICK_SCANNER_TIM_240_NAME) == 0)
+		// {
+		//   // the TiM240 operates directly in the ros coordinate system
+		// }
+		// else
+		// {
+		//   minAngSopas += 90.0;
+		//   maxAngSopas += 90.0;
+		// }
 
-      angleStart10000th = (int) (std::round(10000.0 * minAngSopas));
-      angleEnd10000th = (int) (std::round(10000.0 * maxAngSopas));
-    }
+		angleStart10000th = (int)(std::round(10000.0 * minAngSopas));
+		angleEnd10000th = (int)(std::round(10000.0 * maxAngSopas));
+	}
       char requestOutputAngularRange[MAX_STR_LEN];
       // special for LMS1000 TODO unify this
       if (this->parser_->getCurrentParamPtr()->getScannerName().compare(SICK_SCANNER_LMS_1XXX_NAME) == 0)
@@ -2417,9 +2419,9 @@ namespace sick_scan
         if (this->parser_->getCurrentParamPtr()->getUseScancfgList())
         {
           // config is set with list entry
-      }
-      else
-      {
+        }
+        if (this->parser_->getCurrentParamPtr()->getUseWriteOutputRanges()) // else
+        {
         const char *pcCmdMask = sopasCmdMaskVec[CMD_SET_OUTPUT_RANGES].c_str();
         sprintf(requestOutputAngularRange, pcCmdMask, angleRes10000th, angleStart10000th, angleEnd10000th);
       if (useBinaryCmd)
@@ -2429,7 +2431,7 @@ namespace sick_scan
         UINT16 sendLen;
         std::vector<unsigned char> reqBinary;
         int iStatus = 1;
-        //				const char *askOutputAngularRangeBinMask = "%4y%4ysWN LMPoutputRange %2y%4y%4y%4y";
+        //              const char *askOutputAngularRangeBinMask = "%4y%4ysWN LMPoutputRange %2y%4y%4y%4y";
         // int askOutputAngularRangeBinLen = binScanfGuessDataLenFromMask(askOutputAngularRangeBinMask);
         // askOutputAngularRangeBinLen -= 8;  // due to header and length identifier
 
@@ -2598,8 +2600,7 @@ namespace sick_scan
                                                        << " [deg]");
         }
       }
-      else
-
+      if (this->parser_->getCurrentParamPtr()->getUseWriteOutputRanges()) // else
       {
         askOutputAngularRangeReply.clear();
 
@@ -2742,8 +2743,8 @@ namespace sick_scan
       if (this->parser_->getCurrentParamPtr()->getScannerName().compare(SICK_SCANNER_LMS_5XX_NAME) == 0)
       {
         int filter_echos = 0;
-        rosGetParam(nh, "filter_echos",
-          filter_echos);
+        // rosDeclareParam(nh, "filter_echos", filter_echos);
+        rosGetParam(nh, "filter_echos", filter_echos);
         switch (filter_echos)
         {
         default:outputChannelFlagId = 0b00000001; break;
@@ -2920,7 +2921,7 @@ namespace sick_scan
         {
           if (this->parser_->getCurrentParamPtr()->getUseScancfgList() == true)
           {
-            ROS_INFO("variable ang_res and scan_freq setings for  OEM15xx NAV 3xx or LRD-36XX  has not been implemented");
+            ROS_INFO("variable ang_res and scan_freq settings for  OEM15xx NAV 3xx or LRD-36XX  has not been implemented");
           }
           else
           {
@@ -3270,7 +3271,7 @@ namespace sick_scan
     {
       int cmdId = *it;
       std::vector<unsigned char> tmpReply;
-      //			result = sendSopasAndCheckAnswer(sopasCmdVec[cmdId].c_str(), &tmpReply);
+      //            result = sendSopasAndCheckAnswer(sopasCmdVec[cmdId].c_str(), &tmpReply);
       //      RETURN_ERROR_ON_RESPONSE_TIMEOUT(result, tmpReply); // No response, non-recoverable connection error (return error and do not try other commands)
 
       std::string sopasCmd = sopasCmdVec[cmdId];
@@ -3798,8 +3799,8 @@ namespace sick_scan
         bool dataToProcess = true;
         std::vector<float> vang_vec;
         vang_vec.clear();
-		dstart = NULL;
-		dend = NULL;
+        dstart = NULL;
+        dend = NULL;
 
         while (dataToProcess)
         {
@@ -3943,7 +3944,7 @@ namespace sick_scan
                     else
                     {
                       msg.header.stamp = recvTimeStamp + rosDuration(config_.time_offset); // update timestamp by software-pll
-					}
+                    }
                   }
 
 #ifdef DEBUG_DUMP_ENABLED
@@ -4684,12 +4685,12 @@ namespace sick_scan
                 float *cosAlphaTablePtr = &cosAlphaTable[0];
                 float *sinAlphaTablePtr = &sinAlphaTable[0];
 
-				float *vangPtr = NULL;
-				float *rangeTmpPtr = &rangeTmp[0];
-				if (vang_vec.size() > 0)
-				{
-					vangPtr = &vang_vec[0];
-				}
+                float *vangPtr = NULL;
+                float *rangeTmpPtr = &rangeTmp[0];
+                if (vang_vec.size() > 0)
+                {
+                    vangPtr = &vang_vec[0];
+                }
                 for (size_t i = 0; i < rangeNum; i++)
                 {
                   enum enum_index_descr
@@ -4909,10 +4910,10 @@ namespace sick_scan
             }
           }
           // Start Point
-		  if (dend != NULL)
-		  {
-			  buffer_pos = dend + 1;
-		  }
+          if (dend != NULL)
+          {
+              buffer_pos = dend + 1;
+          }
         } // end of while loop
       }
 

--- a/driver/src/sick_scan_parse_util.cpp
+++ b/driver/src/sick_scan_parse_util.cpp
@@ -173,7 +173,7 @@ bool sick_scan::SickScanParseUtil::SopasToLMPscancfg(const std::string& sopas_re
     success = success && convertBin(sopas_reply, offset, scancfg.active_sector_cnt); // number of active sectors
     int max_sector_cnt = 4; // scancfg.active_sector_cnt // always 4 sectors are transmitted by sopas
     scancfg.sector_cfg.reserve(max_sector_cnt);
-    for (int sector_cnt = 0; success == true && sector_cnt < max_sector_cnt; sector_cnt++)
+    for (int sector_cnt = 0; success == true && sector_cnt < max_sector_cnt && offset < sopas_reply.length(); sector_cnt++)
     {
         sick_scan::SickScanParseUtil::LMPscancfgSector scancfg_sector;
         success = success && convertBin(sopas_reply, offset, scancfg_sector.angular_resolution); // angular resolution in 1/10000 deg

--- a/include/sick_scan/sick_generic_parser.h
+++ b/include/sick_scan/sick_generic_parser.h
@@ -173,6 +173,10 @@ namespace sick_scan
 
     bool getUseScancfgList();
 
+    void setUseWriteOutputRanges(bool _useWriteOutputRanges);
+
+    bool getUseWriteOutputRanges();
+
     void setWaitForReady(bool _waitForReady);
 
     bool getWaitForReady();
@@ -202,6 +206,7 @@ namespace sick_scan
     EVAL_FIELD_SUPPORT useEvalFields;
     int maxEvalFields;
     bool useScancfgList;
+    bool useWriteOutputRanges;
     bool waitForReady;
     bool frEchoFilterAvailable = false;
 

--- a/launch/sick_lrs_4xxx.launch
+++ b/launch/sick_lrs_4xxx.launch
@@ -14,6 +14,22 @@
         <param name="range_max" type="double" value="100.0"/>
         <param name="intensity" type="bool" value="True"/>
         <param name="min_intensity" type="double" value="0.0"/> <!-- Set range of LaserScan messages to infinity, if intensity < min_intensity (default: 0) -->
+        <param name="filter_echos" type="int" value="0"/> <!-- FREchoFilter settings: Use 0 (first echo) for LRS4xxx -->
+        
+        <param name="scan_cfg_list_entry" type="int" value="1"/>
+        <!-- Parameter scan_cfg_list_entry can be set to one of the following modes of the LRS4000 table (sets the scan configuration by "sMN mCLsetscancfglist <mode>")        
+        Mode Name Interlaced ScanFreq ResultScanFreq Resolution TotalResol FieldOfView        
+         1 12.5Hz & 0.040 deg 0x 12.5 Hz 12.5 Hz 0.040 deg 0.040 deg 360 deg
+         2 12.5Hz & 0.060 deg 0x 12.5 Hz 12.5 Hz 0.060 deg 0.060 deg 360 deg
+         4 12.5Hz & 0.100 deg 0x 12.5 Hz 12.5 Hz 0.100 deg 0.100 deg 360 deg
+         5 12.5Hz & 0.120 deg 0x 12.5 Hz 12.5 Hz 0.120 deg 0.120 deg 360 deg
+        11 12.5Hz & 0.020 deg 0x 12.5 Hz 12.5 Hz 0.040 deg 0.020 deg 288 deg
+        71   25Hz & 0.040 deg 0x   25 Hz   25 Hz 0.080 deg 0.040 deg 288 deg
+        61   25Hz & 0.080 deg 0x   25 Hz   25 Hz 0.080 deg 0.080 deg 360 deg
+        62   25Hz & 0.120 deg 0x   25 Hz   25 Hz 0.120 deg 0.120 deg 360 deg
+        64   25Hz & 0.200 deg 0x   25 Hz   25 Hz 0.200 deg 0.200 deg 360 deg
+        65   25Hz & 0.240 deg 0x   25 Hz   25 Hz 0.240 deg 0.240 deg 360 deg
+         -->
 
         <param name="start_services" type="bool" value="True" />                  <!-- Start ros service for cola commands, default: true -->
         <param name="message_monitoring_enabled" type="bool" value="True" />      <!-- Enable message monitoring with reconnect+reinit in case of timeouts, default: true -->


### PR DESCRIPTION
LRS4xxx configuration of scan rate, angular resolution, min and max angle and frame id in the launch file:
```
        <param name="frame_id" type="str" value="cloud"/>
        <param name="min_ang" type="double" value="-3.1415926"/>
        <param name="max_ang" type="double" value="3.1415926"/>
        <param name="scan_cfg_list_entry" type="int" value="1"/>
        <!-- Parameter scan_cfg_list_entry can be set to one of the following modes of the LRS4000 table (sets the scan configuration by "sMN mCLsetscancfglist <mode>")        
        Mode Name Interlaced ScanFreq ResultScanFreq Resolution TotalResol FieldOfView        
         1 12.5Hz & 0.040 deg 0x 12.5 Hz 12.5 Hz 0.040 deg 0.040 deg 360 deg
         2 12.5Hz & 0.060 deg 0x 12.5 Hz 12.5 Hz 0.060 deg 0.060 deg 360 deg
         4 12.5Hz & 0.100 deg 0x 12.5 Hz 12.5 Hz 0.100 deg 0.100 deg 360 deg
         5 12.5Hz & 0.120 deg 0x 12.5 Hz 12.5 Hz 0.120 deg 0.120 deg 360 deg
        11 12.5Hz & 0.020 deg 0x 12.5 Hz 12.5 Hz 0.040 deg 0.020 deg 288 deg
        71   25Hz & 0.040 deg 0x   25 Hz   25 Hz 0.080 deg 0.040 deg 288 deg
        61   25Hz & 0.080 deg 0x   25 Hz   25 Hz 0.080 deg 0.080 deg 360 deg
        62   25Hz & 0.120 deg 0x   25 Hz   25 Hz 0.120 deg 0.120 deg 360 deg
        64   25Hz & 0.200 deg 0x   25 Hz   25 Hz 0.200 deg 0.200 deg 360 deg
        65   25Hz & 0.240 deg 0x   25 Hz   25 Hz 0.240 deg 0.240 deg 360 deg
         -->
```