### PR TITLE
NAV310 + LRS4xxx update, issues #58, #59, #60, #61

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,7 @@ doc/20210712_sick_scan_xd.pptx
 doc/backlog.md
 
 test/emulator/scandata
+
+test/scripts/make_ros1_with_emulator.bash
+
+test/scripts/makeall_ros1_with_emulator.bash

--- a/driver/src/sick_scan_common.cpp
+++ b/driver/src/sick_scan_common.cpp
@@ -479,6 +479,12 @@ namespace sick_scan
     rosDeclareParam(nh, "nodename", nodename);
     rosGetParam(nh, "nodename", nodename);
 
+    if (parser_->getCurrentParamPtr()->getScannerName().compare(SICK_SCANNER_NAV_3XX_NAME) == 0)
+    {
+      // NAV-310 only supports min/max angles of -PI to +PI (resp. 0 to 360 degree in sensor coordinates). To avoid unexpected results, min/max angles can not be set by configuration.
+      config_.min_ang = -M_PI;
+      config_.max_ang = +M_PI;
+    }
 
     // datagram publisher (only for debug)
     rosDeclareParam(nh, "publish_datagram", false);
@@ -536,6 +542,17 @@ namespace sick_scan
 
     rosDeclareParam(nh, "read_timeout_millisec_startup", m_read_timeout_millisec_startup);
     rosGetParam(nh, "read_timeout_millisec_startup", m_read_timeout_millisec_startup);
+
+    if (parser_->getCurrentParamPtr()->getScannerName().compare(SICK_SCANNER_NAV_3XX_NAME) == 0)
+    {
+      // NAV-310 only supports min/max angles of -PI to +PI (resp. 0 to 360 degree in sensor coordinates). To avoid unexpected results, min/max angles can not be set by configuration.
+      if(std::abs(config_.min_ang + M_PI) > FLT_EPSILON || std::abs(config_.max_ang - M_PI) > FLT_EPSILON)
+      {
+        ROS_WARN_STREAM("## WARNING: configured min/max_angle = " << config_.min_ang << "," << config_.max_ang << " not supported by NAV-3xx. min/max_angle = -PI,+PI will be used.");
+        config_.min_ang = -M_PI;
+        config_.max_ang = +M_PI;
+      }
+    }
 
     cloud_marker_ = 0;
     publish_lferec_ = false;
@@ -1529,6 +1546,14 @@ namespace sick_scan
       sopasCmdChain.push_back(CMD_SET_ACCESS_MODE_3); // re-enter authorized client level
       sopasCmdChain.push_back(CMD_GET_SCANDATACONFIGNAV); // Read LMPscancfg by "sRN LMPscancfg"
     }
+    /*
+    if (parser_->getCurrentParamPtr()->getScannerName().compare(SICK_SCANNER_NAV_3XX_NAME) == 0)
+    {
+      sopasCmdChain.push_back(CMD_SET_ACCESS_MODE_3); // re-enter authorized client level
+      sopasCmdChain.push_back("\x02sWN LMDscandatacfg 01 00 1 0 0 0 00 0 0 0 1 1\x03");
+      sopasCmdChain.push_back(CMD_RUN); // Apply changes
+    }
+    */
 
     return (0);
   }
@@ -2148,18 +2173,9 @@ namespace sick_scan
               double stop_ang_rad = (scancfg.sector_cfg[sector_cnt].stop_angle / 10000.0) * (M_PI / 180.0);
               if (parser_->getCurrentParamPtr()->getScannerName().compare(SICK_SCANNER_NAV_3XX_NAME) == 0) // map ros start/stop angle to NAV-3xx logic
               {
-                // NAV-3xx rotates the scan depending on start/stop angles => TODO: Set angle shift to (360 - nav_stop_angle) ???
-                // this->parser_->getCurrentParamPtr()->setScanAngleShift(2 * M_PI - stop_ang_rad);
-                // ROS_INFO_STREAM("NAV-3xx angle shift set to " << rad2deg(this->parser_->getCurrentParamPtr()->getScanAngleShift()) << " deg");
-                // TODO: map ros start/stop angle to NAV-3xx logic
+                // NAV-310 only supports min/max angles 0 to 360 degree in sensor coordinates. To avoid unexpected results, min/max angles can not be set by configuration.
                 start_ang_rad = 0; // this->config_.min_ang;
                 stop_ang_rad = 2 * M_PI; // this->config_.max_ang;
-                /*
-                double start_ang_ros = start_ang_rad, stop_ang_ros = stop_ang_rad;
-                start_ang_rad = sick_scan::normalizeAngleRad(stop_ang_ros - M_PI, 0.0, 2 * M_PI);
-                stop_ang_rad = start_ang_rad + (stop_ang_ros - start_ang_ros);
-                stop_ang_rad = std::min(stop_ang_rad, 2 * M_PI); // stop_ang_rad = sick_scan::normalizeAngleRad(stop_ang_rad, 0.0, 2 * M_PI);
-                */
               }
               else
               {
@@ -4233,7 +4249,13 @@ namespace sick_scan
                               msg.angle_increment = sizeOfSingleAngularStep;
                               msg.angle_max = msg.angle_min + (numberOfItems - 1) * msg.angle_increment;
 
-                              if (this->parser_->getCurrentParamPtr()->getScanMirroredAndShifted())
+                              if (parser_->getCurrentParamPtr()->getScannerName().compare(SICK_SCANNER_NAV_3XX_NAME) == 0)
+                              {
+                                msg.angle_min = (float)(-M_PI);
+                                msg.angle_max = (float)(+M_PI);
+                                msg.angle_increment *= -1.0;
+                              }
+                              else if (this->parser_->getCurrentParamPtr()->getScanMirroredAndShifted()) // i.e. for SICK_SCANNER_LRS_36x0_NAME and SICK_SCANNER_NAV_3XX_NAME
                               {
                                 /* TODO: Check this ...
                                 msg.angle_min -= (float)(M_PI / 2);

--- a/launch/sick_lrs_4xxx.launch
+++ b/launch/sick_lrs_4xxx.launch
@@ -15,7 +15,7 @@
         <param name="intensity" type="bool" value="True"/>
         <param name="min_intensity" type="double" value="0.0"/> <!-- Set range of LaserScan messages to infinity, if intensity < min_intensity (default: 0) -->
         <param name="skip" type="int" value="0" /> <!-- Default: 0 (i.e. publish each scan), otherwise only each n.th scan is published -->
-        <param name="filter_echos" type="int" value="0"/> <!-- FREchoFilter settings: Use 0 (first echo) for LRS4xxx -->
+        <param name="filter_echos" type="int" value="2"/> <!-- FREchoFilter settings: 0 = first echo, 2 = last echo, default: 2 -->
         
         <param name="scan_cfg_list_entry" type="int" value="1"/>
         <!-- Parameter scan_cfg_list_entry can be set to one of the following modes of the LRS4000 table (sets the scan configuration by "sMN mCLsetscancfglist <mode>")        

--- a/launch/sick_nav_3xx.launch
+++ b/launch/sick_nav_3xx.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!-- LAUNCH FILE FOR NAV310 -->
 <!-- NAV310 rotates clockwise and does not support the sWN LMPoutputRange -->
-<!-- The lidar has a angle resolution of 0.75 deg and exports in range of [0 ... 360[ deg 480 shots per scan -->
+<!-- The lidar exports in range of [0 ... 360] deg 480 shots per scan -->
 <!-- Using node option required="true" will close roslaunch after node exits -->
 
 <launch>
@@ -20,11 +20,20 @@
         <param name="port" type="string" value="2112"/>
         <param name="timelimit" type="int" value="5"/>
         <param name="min_intensity" type="double" value="0.0"/> <!-- Set range of LaserScan messages to infinity, if intensity < min_intensity (default: 0) -->
-        <param name="scan_cfg_list_entry" type="int" value="$(arg scan_cfg_list_entry)"/> <!-- only mode 1 is currently supported -->
-        
-        <!-- Currently only start/stop angle 0 to 360 degree in nav coordinates supported. min_ang and max_ang currently ignored, for future use only -->
-        <param name="min_ang" type="double" value="-3.14159265359"/> <!-- default start angle for NAV-3xx: -180 deg in ros coordinates (resp. 0 deg in nav coordinates) -->
-        <param name="max_ang" type="double" value="3.14159265359"/>  <!-- default stop angle for  NAV-3xx: +180 deg in ros coordinates (resp. 360 deg in nav coordinates)  -->
+        <!-- NAV-310 supports start/stop angle 0 to 360 degree in nav coordinates (-180 to +180 degree in ros coordinates). Other values of min_ang and max_ang are ignored -->
+        <param name="scan_cfg_list_entry" type="int" value="$(arg scan_cfg_list_entry)"/> <!-- NAV-310: Modes 1, 2, 5 and 22 are valid settings, other modes not supported -->
+
+        <!-- Parameter scan_cfg_list_entry can be set to one of the following modes of the NAV310 table:
+        Mode Interlaced ScanFreq ResultScanFreq Resolution TotalResol FieldOfView Sector
+         1 0x  8 Hz  8 Hz 0.25   0.25   360  0...360 deg
+         2 0x 15 Hz 15 Hz 0.5    0.5    360  0...360 deg
+         3 0x 10 Hz 10 Hz 0.25   0.25   300 30...330 deg
+         4 0x  5 Hz  5 Hz 0.125  0.125  300 30...330 deg
+         5 0x  6 Hz  6 Hz 0.1875 0.1875 360  0...360 deg
+         8 0x 15 Hz 15 Hz 0.375  0.375  300 30...330 deg
+        21 0x 20 Hz 20 Hz 0.5    0.5    300 30...330 deg
+        22 0x 20 Hz 20 Hz 0.75   0.75   360  0...360 deg
+        -->
 
         <param name="start_services" type="bool" value="True" />                  <!-- Start ros service for cola commands, default: true -->
         <param name="message_monitoring_enabled" type="bool" value="True" />      <!-- Enable message monitoring with reconnect+reinit in case of timeouts, default: true -->


### PR DESCRIPTION
#58 (NAV310): min/max angle removed from config
#59 (NAV310+LRS4xxx): laserscan and pointcloud identical
#60 (LRS4xxx): validated parameter scan_cfg_list_entry and skip
#61 (LRS4xxx): default value echo filter changed to "2" (last echo)