### PR TITLE
fix catkin_lint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,38 +1,40 @@
 ####################################################
-# CMakeLists.txt for project sick_scan_xd
+# CMakeLists.txt for project sick_scan
 ####################################################
 cmake_minimum_required(VERSION 3.5)
+
+project(sick_scan)
 
 # Emulator build options
 if(CMAKE_ENABLE_EMULATOR EQUAL 1)
     option(ENABLE_EMULATOR "Build emulator for offline and unittests (ON) or without emulator (OFF)" ON) # OFF (release) or ON (development)
-    message(STATUS "Option CMAKE_ENABLE_EMULATOR = ${CMAKE_ENABLE_EMULATOR}, building sick_scan with emulator support")
+    message(STATUS "Option CMAKE_ENABLE_EMULATOR = ${CMAKE_ENABLE_EMULATOR}, building ${PROJECT_NAME} with emulator support")
 else()
     option(ENABLE_EMULATOR "Build emulator for offline and unittests (ON) or without emulator (OFF)" OFF) # OFF (release) or ON (development)
-    message(STATUS "Option CMAKE_ENABLE_EMULATOR = ${CMAKE_ENABLE_EMULATOR}, building sick_scan without emulator support")
+    message(STATUS "Option CMAKE_ENABLE_EMULATOR = ${CMAKE_ENABLE_EMULATOR}, building ${PROJECT_NAME} without emulator support")
 endif()
 
 # LDMRS build options
 if(WIN32)
-    option(BUILD_WITH_LDMRS_SUPPORT "Build sick_scan_xd with LDMRS support (ON, libsick_ldmrs from https://github.com/SICKAG/libsick_ldmrs required) or without LDMRS support (OFF)" OFF)
+    option(BUILD_WITH_LDMRS_SUPPORT "Build ${PROJECT_NAME} with LDMRS support (ON, libsick_ldmrs from https://github.com/SICKAG/libsick_ldmrs required) or without LDMRS support (OFF)" OFF)
 elseif(LDMRS EQUAL 0)
-    option(BUILD_WITH_LDMRS_SUPPORT "Build sick_scan_xd with LDMRS support (ON, libsick_ldmrs from https://github.com/SICKAG/libsick_ldmrs required) or without LDMRS support (OFF)" OFF)
+    option(BUILD_WITH_LDMRS_SUPPORT "Build ${PROJECT_NAME} with LDMRS support (ON, libsick_ldmrs from https://github.com/SICKAG/libsick_ldmrs required) or without LDMRS support (OFF)" OFF)
 else()
-    option(BUILD_WITH_LDMRS_SUPPORT "Build sick_scan_xd with LDMRS support (ON, libsick_ldmrs from https://github.com/SICKAG/libsick_ldmrs required) or without LDMRS support (OFF)" ON)
+    option(BUILD_WITH_LDMRS_SUPPORT "Build ${PROJECT_NAME} with LDMRS support (ON, libsick_ldmrs from https://github.com/SICKAG/libsick_ldmrs required) or without LDMRS support (OFF)" ON)
 endif()
 
 # MRS100/SCANSEGMENT_XD/MULTISCAN136 build options
 if(SCANSEGMENT_XD EQUAL 0)
-    option(BUILD_WITH_SCANSEGMENT_XD_SUPPORT "Build sick_scan_xd with SCANSEGMENT_XD support (ON) or without SCANSEGMENT_XD support (OFF)" OFF)
+    option(BUILD_WITH_SCANSEGMENT_XD_SUPPORT "Build ${PROJECT_NAME} with SCANSEGMENT_XD support (ON) or without SCANSEGMENT_XD support (OFF)" OFF)
 else()
-    option(BUILD_WITH_SCANSEGMENT_XD_SUPPORT "Build sick_scan_xd with SCANSEGMENT_XD support (ON) or without SCANSEGMENT_XD support (OFF)" ON)
+    option(BUILD_WITH_SCANSEGMENT_XD_SUPPORT "Build ${PROJECT_NAME} with SCANSEGMENT_XD support (ON) or without SCANSEGMENT_XD support (OFF)" ON)
 endif()
 
 # Linker option visibilty
 if(VISIBILITY EQUAL 0)
-    option(BUILD_LIB_HIDE_FUNCTIONS "Build sick_scan_xd library with function hiding except for SickScanApi-functions (ON) or without function hiding (OFF)" ON)
+    option(BUILD_LIB_HIDE_FUNCTIONS "Build ${PROJECT_NAME} library with function hiding except for SickScanApi-functions (ON) or without function hiding (OFF)" ON)
 else()
-    option(BUILD_LIB_HIDE_FUNCTIONS "Build sick_scan_xd library with function hiding except for SickScanApi-functions (ON) or without function hiding (OFF)" OFF)
+    option(BUILD_LIB_HIDE_FUNCTIONS "Build ${PROJECT_NAME} library with function hiding except for SickScanApi-functions (ON) or without function hiding (OFF)" OFF)
 endif()
 
 # Debug or Release build options
@@ -48,11 +50,10 @@ if(NOT WIN32)
     add_compile_options(-O3)
 endif()
 # Added CMP0048 to avoid unstable warning of build process
-if (POLICY CMP0048)
+if(POLICY CMP0048)
     cmake_policy(SET CMP0048 NEW)
-endif (POLICY CMP0048)
+endif()
 
-project(sick_scan)
 
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
@@ -77,7 +78,7 @@ endif()
 
 if($ENV{ROS_VERSION})
     set(ROS_VERSION $ENV{ROS_VERSION})
-endif($ENV{ROS_VERSION})
+endif()
 add_compile_options(-D__ROS_VERSION=${ROS_VERSION})
 if(ROS_VERSION EQUAL 0)
     add_compile_options(-DROSSIMU)
@@ -118,27 +119,25 @@ endif()
 
 if(ROS_VERSION EQUAL 1)
     find_package(catkin REQUIRED COMPONENTS
-        roscpp
-        roslib # needed ros::package::getPath()
-        sensor_msgs
         diagnostic_updater
         dynamic_reconfigure
         geometry_msgs
-        std_msgs
-        nav_msgs
-        sensor_msgs
-        visualization_msgs
         message_generation
-        message_runtime
+        nav_msgs
+        roscpp
+        roslib # needed ros::package::getPath()
+        sensor_msgs
+        std_msgs
         tf
         tf2
-        )
+        visualization_msgs
+    )
 
     find_package(PkgConfig REQUIRED)
 
     generate_dynamic_reconfigure_options(
-        cfg/SickScan.cfg
         cfg/SickLDMRSDriver.cfg
+        cfg/SickScan.cfg
         cfg/tf_dyn.cfg
     )
 
@@ -146,18 +145,18 @@ if(ROS_VERSION EQUAL 1)
     add_message_files(
         DIRECTORY msg
         FILES
-        SickImu.msg
-        RadarObject.msg
-        RadarPreHeaderDeviceBlock.msg
-        RadarPreHeaderMeasurementParam1Block.msg
-        RadarPreHeaderStatusBlock.msg
-        RadarPreHeaderEncoderBlock.msg
-        RadarPreHeader.msg
-        RadarScan.msg
         Encoder.msg
         LFErecFieldMsg.msg
         LFErecMsg.msg
         LIDoutputstateMsg.msg
+        RadarObject.msg
+        RadarPreHeader.msg
+        RadarPreHeaderDeviceBlock.msg
+        RadarPreHeaderEncoderBlock.msg
+        RadarPreHeaderMeasurementParam1Block.msg
+        RadarPreHeaderStatusBlock.msg
+        RadarScan.msg
+        SickImu.msg
     )
     add_message_files(
         DIRECTORY msg/ldmrs
@@ -180,7 +179,7 @@ if(ROS_VERSION EQUAL 1)
     )
     set(diagnostic_updater_pkg diagnostic_updater)
     add_compile_options(-DROS_DIAGNOSTICS_UPDATER_AVAILABLE)
-endif(ROS_VERSION EQUAL 1)
+endif()
 
 if(ROS_VERSION EQUAL 2)
     #uncomment this lines and change path accordingly
@@ -196,16 +195,16 @@ if(ROS_VERSION EQUAL 2)
             add_compile_options(-DROS_DIAGNOSTICS_UPDATER_AVAILABLE)
         endif()
     endif()
+    find_package(diagnostic_msgs REQUIRED)
+    find_package(geometry_msgs REQUIRED)
+    find_package(nav_msgs REQUIRED)
     find_package(rclcpp REQUIRED)
+    find_package(rosidl_default_generators REQUIRED)
     find_package(sensor_msgs REQUIRED)
     find_package(std_msgs REQUIRED)
-    find_package(nav_msgs REQUIRED)
     find_package(tf2 REQUIRED)
-    find_package(geometry_msgs REQUIRED)
-    find_package(diagnostic_msgs REQUIRED)
-    find_package(visualization_msgs REQUIRED)
     find_package(tf2_ros REQUIRED)
-    find_package(rosidl_default_generators REQUIRED)
+    find_package(visualization_msgs REQUIRED)
     if(ENABLE_EMULATOR EQUAL ON)
         set(ROSIDL_EMULATOR_FILES
             # emulator messages
@@ -296,13 +295,13 @@ if(ROS_VERSION EQUAL 2)
         "srv/SCsoftresetSrv.srv"
         "srv/SickScanExitSrv.srv"
         ${ROSIDL_EMULATOR_FILES}
-        DEPENDENCIES builtin_interfaces std_msgs nav_msgs geometry_msgs sensor_msgs
+        DEPENDENCIES builtin_interfaces geometry_msgs nav_msgs sensor_msgs std_msgs
     )
-endif(ROS_VERSION EQUAL 2)
+endif()
 
 # Support for LDMRS
 if(BUILD_WITH_LDMRS_SUPPORT EQUAL ON)
-    message(STATUS "Building sick_scan with LDMRS support")
+    message(STATUS "Building ${PROJECT_NAME} with LDMRS support")
     add_compile_options(-DLDMRS_SUPPORT=1)
     find_package(SickLDMRS REQUIRED)
     set(LDMRS_INCLUDES ${SICK_LDMRS_INCLUDE_DIRS})
@@ -313,12 +312,12 @@ if(BUILD_WITH_LDMRS_SUPPORT EQUAL ON)
     message(STATUS "LDMRS_TARGET_DEPENDENCIES: ${LDMRS_TARGET_DEPENDENCIES}")
     message(STATUS "SICK_LDMRS_LIBRARIES: ${SICK_LDMRS_LIBRARIES}")
 else()
-    message(STATUS "Building sick_scan without ldmrs support")
+    message(STATUS "Building ${PROJECT_NAME} without ldmrs support")
 endif()
 
 # Support for MRS100/SCANSEGMENT_XD/MULTISCAN136
 if(BUILD_WITH_SCANSEGMENT_XD_SUPPORT EQUAL ON)
-    message(STATUS "Building sick_scan with SCANSEGMENT_XD support")
+    message(STATUS "Building ${PROJECT_NAME} with SCANSEGMENT_XD support")
     add_compile_options(-DSCANSEGMENT_XD_SUPPORT=1)
     # msgpack11
     if(WIN32 OR ROS_VERSION EQUAL 0)
@@ -338,7 +337,7 @@ if(BUILD_WITH_SCANSEGMENT_XD_SUPPORT EQUAL ON)
     # sick_scansegment_xd sources
     file(GLOB SCANSEGMENT_XD_SOURCES driver/src/sick_scansegment_xd/*.cpp)
 else()
-    message(STATUS "Building sick_scan without SCANSEGMENT_XD support")
+    message(STATUS "Building ${PROJECT_NAME} without SCANSEGMENT_XD support")
 endif()
  
 if(ENABLE_EMULATOR EQUAL ON AND ROS_VERSION EQUAL 1)
@@ -359,37 +358,29 @@ if(ENABLE_EMULATOR EQUAL ON AND ROS_VERSION EQUAL 1)
     add_service_files(
         DIRECTORY test/emulator/srv
         FILES
-        SickLocColaTelegramSrv.srv
-        SickLocRequestTimestampSrv.srv
-        SickLocSetResultModeSrv.srv
-        SickLocSetResultPoseIntervalSrv.srv
-        SickLocIsSystemReadySrv.srv
-        SickLocSetPoseSrv.srv
-        SickLocSetResultPortSrv.srv
-        SickLocStartLocalizingSrv.srv
-        SickLocStopSrv.srv
-        SickLocRequestResultDataSrv.srv
-        SickLocSetResultEndiannessSrv.srv
-        SickLocSetResultPoseEnabledSrv.srv
-        SickLocStateSrv.srv
-        SickLocTimeSyncSrv.srv
         SickDevGetLidarConfigSrv.srv
         SickDevGetLidarIdentSrv.srv
         SickDevGetLidarStateSrv.srv
+        SickDevIMUActiveSrv.srv
+        SickDevSetIMUActiveSrv.srv
         SickDevSetLidarConfigSrv.srv
         SickGetSoftwareVersionSrv.srv
         SickLocAutoStartActiveSrv.srv
         SickLocAutoStartSavePoseIntervalSrv.srv
         SickLocAutoStartSavePoseSrv.srv
+        SickLocColaTelegramSrv.srv
         SickLocForceUpdateSrv.srv
-        SickLocInitializePoseSrv.srv
         SickLocInitialPoseSrv.srv
+        SickLocInitializePoseSrv.srv
+        SickLocIsSystemReadySrv.srv
         SickLocMapSrv.srv
         SickLocMapStateSrv.srv
         SickLocOdometryActiveSrv.srv
         SickLocOdometryPortSrv.srv
         SickLocOdometryRestrictYMotionSrv.srv
         SickLocReflectorsForSupportActiveSrv.srv
+        SickLocRequestResultDataSrv.srv
+        SickLocRequestTimestampSrv.srv
         SickLocResultEndiannessSrv.srv
         SickLocResultModeSrv.srv
         SickLocResultPortSrv.srv
@@ -403,35 +394,58 @@ if(ENABLE_EMULATOR EQUAL ON AND ROS_VERSION EQUAL 1)
         SickLocSetOdometryActiveSrv.srv
         SickLocSetOdometryPortSrv.srv
         SickLocSetOdometryRestrictYMotionSrv.srv
+        SickLocSetPoseSrv.srv
         SickLocSetReflectorsForSupportActiveSrv.srv
+        SickLocSetResultEndiannessSrv.srv
+        SickLocSetResultModeSrv.srv
+        SickLocSetResultPortSrv.srv
+        SickLocSetResultPoseEnabledSrv.srv
+        SickLocSetResultPoseIntervalSrv.srv
         SickLocSetRingBufferRecordingActiveSrv.srv
         SickLocStartDemoMappingSrv.srv
+        SickLocStartLocalizingSrv.srv
+        SickLocStateSrv.srv
+        SickLocStopSrv.srv
+        SickLocTimeSyncSrv.srv
         SickReportUserMessageSrv.srv
         SickSavePermanentSrv.srv
-        SickDevSetIMUActiveSrv.srv
-        SickDevIMUActiveSrv.srv
     ) 
 endif()
 
 if(ROS_VERSION EQUAL 1)
     generate_messages(
         DEPENDENCIES
-        std_msgs
         geometry_msgs
-        sensor_msgs
         nav_msgs
+        sensor_msgs
+        std_msgs
     )
 
     catkin_package(
-        CATKIN_DEPENDS message_runtime roscpp sensor_msgs ${diagnostic_updater_pkg} dynamic_reconfigure tf tf2 # pcl_conversions pcl_ros tf tf2
-        LIBRARIES sick_scan_lib sick_scan_shared_lib
+        CATKIN_DEPENDS
+            diagnostic_msgs
+            ${diagnostic_updater_pkg}
+            dynamic_reconfigure
+            geometry_msgs
+            message_runtime
+            nav_msgs
+            # pcl_conversions
+            # pcl_ros
+            roscpp
+            sensor_msgs
+            std_msgs
+            tf
+            tf2
+            # tf tf2
+            visualization_msgs
+        LIBRARIES ${PROJECT_NAME}_lib ${PROJECT_NAME}_shared_lib
         INCLUDE_DIRS include
     )
 endif()
 
-include_directories(include include/sick_scan_xd_api include/tinyxml ${catkin_INCLUDE_DIRS} ${LDMRS_INCLUDES} include/sick_scan tools/test_server/include roswrap/src/include/launchparser)
+include_directories(include include/${PROJECT_NAME}_xd_api include/tinyxml ${catkin_INCLUDE_DIRS} ${LDMRS_INCLUDES} include/${PROJECT_NAME} tools/test_server/include roswrap/src/include/launchparser)
 if(ROS_VERSION EQUAL 0)
-include_directories(roswrap/src/msg_header)
+    include_directories(roswrap/src/msg_header)
 endif()
 
 if(ROS_VERSION EQUAL 1)
@@ -441,68 +455,68 @@ if(ROS_VERSION EQUAL 1)
         file(GLOB SRC_WIN_FILES roswrap/helper_win/usleep/usleep.c)
     endif()
     set(SICK_SCAN_LIB_SRC
-        driver/src/dataDumper.cpp
-        driver/src/sick_scan_common.cpp
         driver/src/abstract_parser.cpp
-        driver/src/tcp/tcp.cpp
+        driver/src/binPrintf.cpp
+        driver/src/binScanf.cpp
+        driver/src/dataDumper.cpp
+        driver/src/helper/angle_compensator.cpp
+        driver/src/sick_cloud_transform.cpp
+        driver/src/sick_generic_callback.cpp
+        driver/src/sick_generic_field_mon.cpp
+        driver/src/sick_generic_imu.cpp
+        driver/src/sick_generic_laser.cpp
+        driver/src/sick_generic_monitoring.cpp
+        driver/src/sick_generic_parser.cpp
+        driver/src/sick_generic_radar.cpp
+        driver/src/sick_lmd_scandata_parser.cpp
+        driver/src/${PROJECT_NAME}_common.cpp
+        driver/src/${PROJECT_NAME}_common_nw.cpp
+        driver/src/${PROJECT_NAME}_common_tcp.cpp
+        driver/src/${PROJECT_NAME}_config_internal.cpp
+        driver/src/${PROJECT_NAME}_marker.cpp
+        driver/src/${PROJECT_NAME}_messages.cpp
+        driver/src/${PROJECT_NAME}_parse_util.cpp
+        driver/src/${PROJECT_NAME}_services.cpp
+        driver/src/${PROJECT_NAME}_xd_api/api_impl.cpp
+        driver/src/${PROJECT_NAME}_xd_api/${PROJECT_NAME}_api_converter.cpp
+        driver/src/softwarePLL.cpp
         driver/src/tcp/Mutex.cpp
         driver/src/tcp/SickThread.cpp
-        driver/src/tcp/errorhandler.cpp
-        driver/src/tcp/toolbox.cpp
         driver/src/tcp/Time.cpp
         driver/src/tcp/colaa.cpp
         driver/src/tcp/colab.cpp
+        driver/src/tcp/errorhandler.cpp
+        driver/src/tcp/tcp.cpp
+        driver/src/tcp/toolbox.cpp
         driver/src/tcp/wsa_init.cpp
-        driver/src/binPrintf.cpp
-        driver/src/binScanf.cpp
-        driver/src/sick_cloud_transform.cpp
-        driver/src/sick_scan_common_tcp.cpp
-        driver/src/sick_generic_callback.cpp
-        driver/src/sick_generic_radar.cpp
-        driver/src/sick_generic_imu.cpp
-        driver/src/sick_generic_parser.cpp
-        driver/src/sick_generic_monitoring.cpp
-        driver/src/sick_lmd_scandata_parser.cpp
-        driver/src/sick_scan_common_nw.cpp
-        driver/src/sick_scan_config_internal.cpp
-        driver/src/softwarePLL.cpp
-        driver/src/helper/angle_compensator.cpp
-        driver/src/sick_generic_field_mon.cpp
-        driver/src/sick_scan_marker.cpp
-        driver/src/sick_scan_messages.cpp
-        driver/src/sick_scan_parse_util.cpp
-        driver/src/sick_scan_services.cpp
-        driver/src/sick_generic_laser.cpp
-        driver/src/sick_scan_xd_api/api_impl.cpp
-        driver/src/sick_scan_xd_api/sick_scan_api_converter.cpp
-        roswrap/src/launchparser/launchparser.cpp 
         driver/src/tinyxml/tinystr.cpp
         driver/src/tinyxml/tinyxml.cpp
         driver/src/tinyxml/tinyxmlerror.cpp
         driver/src/tinyxml/tinyxmlparser.cpp
+        roswrap/src/launchparser/launchparser.cpp
         ${LDMRS_SOURCES}
         ${SCANSEGMENT_XD_SOURCES}
         ${SRC_WIN_FILES}
     )
-    add_library(sick_scan_lib STATIC ${SICK_SCAN_LIB_SRC})
+    add_library(${PROJECT_NAME}_lib STATIC ${SICK_SCAN_LIB_SRC})
     # target_compile_options(sick_scan_lib PUBLIC "-fPIC")
-    add_library(sick_scan_shared_lib SHARED ${SICK_SCAN_LIB_SRC})
+    add_library(${PROJECT_NAME}_shared_lib SHARED ${SICK_SCAN_LIB_SRC})
 
-    add_dependencies(sick_scan_lib
+    add_dependencies(${PROJECT_NAME}_lib
         ${PROJECT_NAME}_gencfg
         ${catkin_EXPORTED_TARGETS}
         ${${PROJECT_NAME}_EXPORTED_TARGETS})
-    add_dependencies(sick_scan_shared_lib
+    add_dependencies(${PROJECT_NAME}_shared_lib
         ${PROJECT_NAME}_gencfg
         ${catkin_EXPORTED_TARGETS}
         ${${PROJECT_NAME}_EXPORTED_TARGETS})
 
-    target_link_libraries(sick_scan_lib ${MSGPACK11_LIBRARIES} ${catkin_LIBRARIES})
-    target_link_libraries(sick_scan_shared_lib ${MSGPACK11_LIBRARIES} ${catkin_LIBRARIES})
+    target_link_libraries(${PROJECT_NAME}_lib ${MSGPACK11_LIBRARIES} ${catkin_LIBRARIES})
+    target_link_libraries(${PROJECT_NAME}_shared_lib ${MSGPACK11_LIBRARIES} ${catkin_LIBRARIES})
 
     add_executable(sick_generic_caller driver/src/sick_generic_caller.cpp)
     
-    target_link_libraries(sick_generic_caller sick_scan_lib ${SICK_LDMRS_LIBRARIES} ${MSGPACK11_LIBRARIES})
+    target_link_libraries(sick_generic_caller ${PROJECT_NAME}_lib ${SICK_LDMRS_LIBRARIES} ${MSGPACK11_LIBRARIES})
     
     #
     #  radar_object_marker (receives radar msg. and publishes marker array for rviz or similar
@@ -511,7 +525,7 @@ if(ROS_VERSION EQUAL 1)
     #     tools/radar_object_marker/src/radar_object_marker.cpp
     #     tools/pcl_converter/src/gnuplotPaletteReader.cpp
     #     include/radar_object_marker/radar_object_marker.h)
-    # target_link_libraries(radar_object_marker sick_scan_lib ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+    # target_link_libraries(radar_object_marker ${PROJECT_NAME}_lib ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
     #
     # pcl_converter disabled to avoid dependency to pcl
@@ -519,8 +533,8 @@ if(ROS_VERSION EQUAL 1)
     # add_executable(pcl_converter tools/pcl_converter/src/pcl_converter.cpp tools/pcl_converter/src/gnuplotPaletteReader.cpp)
     # target_link_libraries(pcl_converter ${catkin_LIBRARIES})
 
-    # add_executable(sick_scan_test test/src/sick_scan_test.cpp)
-    # target_link_libraries(sick_scan_test ${catkin_LIBRARIES} ${roslib_LIBRARIES} sick_scan_lib ${Boost_LIBRARIES})
+    # add_executable(${PROJECT_NAME}_test test/src/${PROJECT_NAME}_test.cpp)
+    # target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES} ${roslib_LIBRARIES} ${PROJECT_NAME}_lib ${Boost_LIBRARIES})
 
 else() # i.e. (ROS_VERSION EQUAL 0 OR ROS_VERSION EQUAL 2)
 
@@ -532,141 +546,141 @@ else() # i.e. (ROS_VERSION EQUAL 0 OR ROS_VERSION EQUAL 2)
     if(ROS_VERSION EQUAL 0)
         include_directories(roswrap/src/include roswrap/src/rossimu/melodic/include roswrap/src/rossimu/kinetic/include roswrap/src/cfgsimu roswrap/src/toojpeg roswrap/src/tools)
         file(GLOB SRC_ROSSIMU_FILES 
-            roswrap/src/cfgsimu/sick_scan/time_modi.cpp
+            roswrap/src/cfgsimu/${PROJECT_NAME}/time_modi.cpp
             roswrap/src/rossimu/kinetic/src/rossimu.cpp
             roswrap/src/rossimu/kinetic/src/duration.cpp
             roswrap/src/rossimu/kinetic/src/rate.cpp
-            roswrap/src/tools/sick_scan/pointcloud_utils.cpp
+            roswrap/src/tools/${PROJECT_NAME}/pointcloud_utils.cpp
         )
     endif()
 
     set(SICK_SCAN_LIB_SRC
-        roswrap/src/getopt/getopt.c
-        roswrap/src/toojpeg/toojpeg.cpp
-        roswrap/src/launchparser/launchparser.cpp 
-        driver/src/binScanf.cpp
-        driver/src/dataDumper.cpp
-        driver/src/sick_cloud_transform.cpp
-        driver/src/sick_generic_callback.cpp
-        driver/src/sick_generic_imu.cpp
-        driver/src/sick_generic_parser.cpp
-        driver/src/sick_lmd_scandata_parser.cpp
-        driver/src/sick_scan_common.cpp
-        driver/src/sick_scan_common_nw.cpp
-        driver/src/sick_scan_common_tcp.cpp
         driver/src/abstract_parser.cpp
         driver/src/binPrintf.cpp
+        driver/src/binScanf.cpp
+        driver/src/dataDumper.cpp
+        driver/src/helper/angle_compensator.cpp
+        driver/src/sick_cloud_transform.cpp
+        driver/src/sick_generic_callback.cpp
         driver/src/sick_generic_field_mon.cpp
+        driver/src/sick_generic_imu.cpp
         driver/src/sick_generic_laser.cpp
         driver/src/sick_generic_monitoring.cpp
+        driver/src/sick_generic_parser.cpp
         driver/src/sick_generic_radar.cpp
-        driver/src/sick_scan_marker.cpp
-        driver/src/sick_scan_messages.cpp
-        driver/src/sick_scan_parse_util.cpp
-        driver/src/sick_scan_services.cpp
+        driver/src/sick_lmd_scandata_parser.cpp
+        driver/src/${PROJECT_NAME}_common.cpp
+        driver/src/${PROJECT_NAME}_common_nw.cpp
+        driver/src/${PROJECT_NAME}_common_tcp.cpp
+        driver/src/${PROJECT_NAME}_marker.cpp
+        driver/src/${PROJECT_NAME}_messages.cpp
+        driver/src/${PROJECT_NAME}_parse_util.cpp
+        driver/src/${PROJECT_NAME}_services.cpp
+        driver/src/${PROJECT_NAME}_xd_api/api_impl.cpp
+        driver/src/${PROJECT_NAME}_xd_api/${PROJECT_NAME}_api_converter.cpp
+        driver/src/softwarePLL.cpp
+        driver/src/tcp/Mutex.cpp
+        driver/src/tcp/SickThread.cpp
+        driver/src/tcp/Time.cpp
+        driver/src/tcp/colaa.cpp
+        driver/src/tcp/colab.cpp
+        driver/src/tcp/errorhandler.cpp
+        driver/src/tcp/tcp.cpp
+        driver/src/tcp/toolbox.cpp
+        driver/src/tcp/wsa_init.cpp
         driver/src/tinyxml/tinystr.cpp
         driver/src/tinyxml/tinyxml.cpp
         driver/src/tinyxml/tinyxmlerror.cpp
         driver/src/tinyxml/tinyxmlparser.cpp
-        driver/src/tcp/colaa.cpp
-        driver/src/tcp/colab.cpp
-        driver/src/tcp/errorhandler.cpp
-        driver/src/tcp/Mutex.cpp
-        driver/src/tcp/SickThread.cpp
-        driver/src/tcp/tcp.cpp
-        driver/src/tcp/Time.cpp
-        driver/src/tcp/toolbox.cpp
-        driver/src/tcp/wsa_init.cpp
-        driver/src/softwarePLL.cpp
-        driver/src/helper/angle_compensator.cpp
-        driver/src/sick_scan_xd_api/api_impl.cpp
-        driver/src/sick_scan_xd_api/sick_scan_api_converter.cpp
+        roswrap/src/getopt/getopt.c
+        roswrap/src/launchparser/launchparser.cpp
+        roswrap/src/toojpeg/toojpeg.cpp
         ${LDMRS_SOURCES}
         ${SCANSEGMENT_XD_SOURCES}
         ${SRC_ROSSIMU_FILES}
         ${SRC_WIN_FILES}
     )
-    add_library(sick_scan_lib STATIC ${SICK_SCAN_LIB_SRC})
+    add_library(${PROJECT_NAME}_lib STATIC ${SICK_SCAN_LIB_SRC})
     # target_compile_options(sick_scan_lib PUBLIC "-fPIC")
-    add_library(sick_scan_shared_lib SHARED ${SICK_SCAN_LIB_SRC})
+    add_library(${PROJECT_NAME}_shared_lib SHARED ${SICK_SCAN_LIB_SRC})
     if(ROS_VERSION EQUAL 0)    
-        # target_compile_options(sick_scan_shared_lib PUBLIC "-fPIC")
-        # target_link_options(sick_scan_shared_lib PUBLIC "-fPIC")
-        target_link_libraries(sick_scan_shared_lib ${SICK_LDMRS_LIBRARIES} ${MSGPACK11_LIBRARIES})
+        # target_compile_options(${PROJECT_NAME}_shared_lib PUBLIC "-fPIC")
+        # target_link_options(${PROJECT_NAME}_shared_lib PUBLIC "-fPIC")
+        target_link_libraries(${PROJECT_NAME}_shared_lib ${SICK_LDMRS_LIBRARIES} ${MSGPACK11_LIBRARIES})
     endif()
     add_executable(sick_generic_caller driver/src/sick_generic_caller.cpp)
-    target_link_libraries(sick_generic_caller sick_scan_lib ${SICK_LDMRS_LIBRARIES} ${MSGPACK11_LIBRARIES})
+    target_link_libraries(sick_generic_caller ${PROJECT_NAME}_lib ${SICK_LDMRS_LIBRARIES} ${MSGPACK11_LIBRARIES})
 
 endif()
 
 if(ROS_VERSION EQUAL 2)
 
     ament_target_dependencies(
-        sick_scan_lib
+        ${PROJECT_NAME}_lib
         "rclcpp"
         "sensor_msgs"
         "std_msgs"
         "geometry_msgs"
         "diagnostic_msgs" 
-            "nav_msgs"
-            "visualization_msgs"
-            "tf2_ros"
-            "${diagnostic_updater_pkg}"
+        "nav_msgs"
+        "visualization_msgs"
+        "tf2_ros"
+        "${diagnostic_updater_pkg}"
         ${LDMRS_TARGET_DEPENDENCIES}
     )
 
     ament_target_dependencies(
-        sick_scan_shared_lib
+        ${PROJECT_NAME}_shared_lib
         "rclcpp"
         "sensor_msgs"
         "std_msgs"
         "geometry_msgs"
         "diagnostic_msgs" 
-            "nav_msgs"
-            "visualization_msgs"
-            "tf2_ros"
-            "${diagnostic_updater_pkg}"
-            ${LDMRS_TARGET_DEPENDENCIES}
+        "nav_msgs"
+        "visualization_msgs"
+        "tf2_ros"
+        "${diagnostic_updater_pkg}"
+        ${LDMRS_TARGET_DEPENDENCIES}
     )
 
     ament_target_dependencies(
-            sick_generic_caller
-            "rclcpp"
-            "sensor_msgs"
-            "std_msgs"
-            "geometry_msgs"
-            "diagnostic_msgs"
-            "nav_msgs"
-            "visualization_msgs"
-            "tf2_ros"
-            "${diagnostic_updater_pkg}"
+        sick_generic_caller
+        "rclcpp"
+        "sensor_msgs"
+        "std_msgs"
+        "geometry_msgs"
+        "diagnostic_msgs"
+        "nav_msgs"
+        "visualization_msgs"
+        "tf2_ros"
+        "${diagnostic_updater_pkg}"
         ${LDMRS_TARGET_DEPENDENCIES}
     )
 
     if(WIN32 OR EXISTS "/opt/ros/eloquent" OR EXISTS "/opt/ros/foxy") # rosidl_typesupport for ROS2 eloquent and foxy
-        rosidl_target_interfaces(sick_scan_lib ${PROJECT_NAME} "rosidl_typesupport_cpp")
-	rosidl_target_interfaces(sick_scan_shared_lib ${PROJECT_NAME} "rosidl_typesupport_cpp")
+        rosidl_target_interfaces(${PROJECT_NAME}_lib ${PROJECT_NAME} "rosidl_typesupport_cpp")
+        rosidl_target_interfaces(${PROJECT_NAME}_shared_lib ${PROJECT_NAME} "rosidl_typesupport_cpp")
         # rosidl_target_interfaces(sick_generic_caller ${PROJECT_NAME} "rosidl_typesupport_cpp")
     else() # rosidl_typesupport for ROS2 humble or later
         rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
-        target_link_libraries(sick_scan_lib "${cpp_typesupport_target}")
-        target_link_libraries(sick_scan_shared_lib "${cpp_typesupport_target}")
+        target_link_libraries(${PROJECT_NAME}_lib "${cpp_typesupport_target}")
+        target_link_libraries(${PROJECT_NAME}_shared_lib "${cpp_typesupport_target}")
         target_link_libraries(sick_generic_caller "${cpp_typesupport_target}")
     endif()
 
-endif(ROS_VERSION EQUAL 2)
+endif()
 
 # Build test and usage example for sick_scan_xd_api
-add_executable(sick_scan_xd_api_test 
-    test/src/sick_scan_xd_api/sick_scan_xd_api_test.cpp
-    test/src/sick_scan_xd_api/sick_scan_xd_api_wrapper.c
-    test/src/sick_scan_xd_api/toojpeg/toojpeg.cpp
-    driver/src/sick_scan_xd_api/sick_scan_api_converter.cpp
+add_executable(${PROJECT_NAME}_xd_api_test
+    driver/src/${PROJECT_NAME}_xd_api/${PROJECT_NAME}_api_converter.cpp
+    test/src/${PROJECT_NAME}_xd_api/${PROJECT_NAME}_xd_api_test.cpp
+    test/src/${PROJECT_NAME}_xd_api/${PROJECT_NAME}_xd_api_wrapper.c
+    test/src/${PROJECT_NAME}_xd_api/toojpeg/toojpeg.cpp
 )
-target_include_directories(sick_scan_xd_api_test PUBLIC test/src/sick_scan_xd_api/toojpeg)
+target_include_directories(${PROJECT_NAME}_xd_api_test PUBLIC test/src/${PROJECT_NAME}_xd_api/toojpeg)
 if(ROS_VERSION EQUAL 1)
-    target_link_libraries(sick_scan_xd_api_test ${catkin_LIBRARIES})
-    add_dependencies(sick_scan_xd_api_test
+    target_link_libraries(${PROJECT_NAME}_xd_api_test ${catkin_LIBRARIES})
+    add_dependencies(${PROJECT_NAME}_xd_api_test
         ${PROJECT_NAME}_gencfg
         ${catkin_EXPORTED_TARGETS}
         ${${PROJECT_NAME}_EXPORTED_TARGETS})
@@ -674,27 +688,27 @@ endif()
 
 # install sick_scan_shared_lib incl. API headerfiles
 if(ROS_VERSION EQUAL 0)
-    set_target_properties(sick_scan_shared_lib PROPERTIES PUBLIC_HEADER "include/sick_scan_xd_api/sick_scan_api.h;python/api/sick_scan_api.py")
-    install(TARGETS sick_scan_shared_lib 
+    set_target_properties(${PROJECT_NAME}_shared_lib PROPERTIES PUBLIC_HEADER "include/sick_scan_xd_api/sick_scan_api.h;python/api/sick_scan_api.py")
+    install(TARGETS ${PROJECT_NAME}_shared_lib
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 endif()
 
 if(ROS_VERSION EQUAL 1)
-    install(TARGETS sick_scan_lib sick_scan_shared_lib
+    install(TARGETS ${PROJECT_NAME}_lib ${PROJECT_NAME}_shared_lib
         DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
     install(TARGETS sick_generic_caller
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-    install(TARGETS sick_scan_xd_api_test
+    install(TARGETS ${PROJECT_NAME}_xd_api_test
         RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
-    # install(TARGETS sick_scan_test RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+    # install(TARGETS ${PROJECT_NAME}_test RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
     install(FILES include/${PROJECT_NAME}/abstract_parser.h
-        include/${PROJECT_NAME}/sick_scan_common.h
+        include/${PROJECT_NAME}/${PROJECT_NAME}_common.h
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
     install(DIRECTORY test/
@@ -710,28 +724,27 @@ if(ROS_VERSION EQUAL 1)
 
     install(DIRECTORY urdf/
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/urdf)
-endif(ROS_VERSION EQUAL 1)
+endif()
 
 if(ROS_VERSION EQUAL 2)
-    install(TARGETS sick_generic_caller sick_scan_xd_api_test
+    install(TARGETS sick_generic_caller ${PROJECT_NAME}_xd_api_test
         DESTINATION lib/${PROJECT_NAME})
 
-    install(TARGETS sick_scan_lib sick_scan_shared_lib
+    install(TARGETS ${PROJECT_NAME}_lib ${PROJECT_NAME}_shared_lib
         DESTINATION lib)
 
     install(DIRECTORY launch
         DESTINATION share/${PROJECT_NAME})
         
     ament_package()        
-endif(ROS_VERSION EQUAL 2)
+endif()
 
 #
-# build and install sick_scan_emulator
+# build and install ${PROJECT_NAME}_emulator
 #
-if(ENABLE_EMULATOR EQUAL ON AND (NOT WIN32 OR ROS_VERSION EQUAL 2)) # sick_scan_emulator not supported on native Windows
-    add_executable(sick_scan_emulator
-        test/emulator/src/test_server.cpp
-        test/emulator/src/test_server_thread.cpp
+if(ENABLE_EMULATOR EQUAL ON AND (NOT WIN32 OR ROS_VERSION EQUAL 2)) # ${PROJECT_NAME}_emulator not supported on native Windows
+    add_executable(${PROJECT_NAME}_emulator
+        test/emulator/src/SoftwarePLL.cpp
         test/emulator/src/client_socket.cpp
         test/emulator/src/cola_converter.cpp
         test/emulator/src/cola_encoder.cpp
@@ -743,22 +756,23 @@ if(ENABLE_EMULATOR EQUAL ON AND (NOT WIN32 OR ROS_VERSION EQUAL 2)) # sick_scan_
         test/emulator/src/result_port_parser.cpp
         test/emulator/src/ros_wrapper.cpp
         test/emulator/src/server_socket.cpp
-        test/emulator/src/SoftwarePLL.cpp
+        test/emulator/src/test_server.cpp
+        test/emulator/src/test_server_thread.cpp
         test/emulator/src/testcase_generator.cpp
         test/emulator/src/utils.cpp
         ${SRC_ROSSIMU_FILES}
         ${SRC_WIN_FILES}
         )
-    target_link_libraries(sick_scan_emulator
+    target_link_libraries(${PROJECT_NAME}_emulator
         ${catkin_LIBRARIES}
         ${roslib_LIBRARIES}
-        sick_scan_lib
+        ${PROJECT_NAME}_lib
         ${MSGPACK11_LIBRARIES} 
         ${LIB_JSONCPP})
-    target_include_directories(sick_scan_emulator PUBLIC test test/emulator/include)
+    target_include_directories(${PROJECT_NAME}_emulator PUBLIC test test/emulator/include)
     
     if(ROS_VERSION EQUAL 1)
-        install(TARGETS sick_scan_emulator
+        install(TARGETS ${PROJECT_NAME}_emulator
             RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
         install(DIRECTORY test/emulator/launch/
             DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)
@@ -767,7 +781,7 @@ if(ENABLE_EMULATOR EQUAL ON AND (NOT WIN32 OR ROS_VERSION EQUAL 2)) # sick_scan_
         install(DIRECTORY test/emulator/scandata/
             DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/scandata)
     else()
-        install(TARGETS sick_scan_emulator
+        install(TARGETS ${PROJECT_NAME}_emulator
             RUNTIME DESTINATION lib/${PROJECT_NAME})
         install(DIRECTORY test/emulator/launch/
             DESTINATION share/${PROJECT_NAME})
@@ -783,16 +797,16 @@ endif()
 #
 if(ENABLE_EMULATOR EQUAL ON)
     add_executable(test_server 
-        tools/test_server/src/test_server.cpp 
-        tools/test_server/src/test_server_cola_msg.cpp 
-        tools/test_server/src/test_server_ldmrs_msg.cpp 
-        tools/test_server/src/test_server_thread.cpp
-        test/emulator/src/server_socket.cpp)
-    target_link_libraries(test_server sick_scan_lib ${SICK_LDMRS_LIBRARIES} ${MSGPACK11_LIBRARIES} ${LIB_JSONCPP})
+        test/emulator/src/server_socket.cpp
+        tools/test_server/src/test_server.cpp
+        tools/test_server/src/test_server_cola_msg.cpp
+        tools/test_server/src/test_server_ldmrs_msg.cpp
+        tools/test_server/src/test_server_thread.cpp)
+    target_link_libraries(test_server ${PROJECT_NAME}_lib ${SICK_LDMRS_LIBRARIES} ${MSGPACK11_LIBRARIES} ${LIB_JSONCPP})
     target_include_directories(test_server PUBLIC test test/emulator/include)
     if(ROS_VERSION EQUAL 2)
         ament_target_dependencies(test_server "rclcpp" )
-    endif(ROS_VERSION EQUAL 2)
+    endif()
     install(TARGETS 
         test_server
         DESTINATION lib/${PROJECT_NAME})
@@ -800,4 +814,5 @@ if(ENABLE_EMULATOR EQUAL ON)
         tools/test_server/config
         tools/test_server/launch
         DESTINATION share/${PROJECT_NAME})
-endif() 
+endif()
+

--- a/package.xml
+++ b/package.xml
@@ -16,27 +16,30 @@
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
   <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
-  <build_depend condition="$ROS_VERSION == 1">message_runtime</build_depend>
   <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
 
   <depend condition="$ROS_VERSION == 1">diagnostic_updater</depend>
   <depend condition="$ROS_VERSION == 1">dynamic_reconfigure</depend>
   <depend condition="$BUILD_WITH_LDMRS_SUPPORT == True">libsick_ldmrs</depend>
   <depend condition="$ROS_VERSION == 1">roscpp</depend>
-  <depend condition="$ROS_VERSION == 1">rospy</depend>
+  <depend condition="$ROS_VERSION == 1">roslib</depend>
   <depend condition="$ROS_VERSION == 1">tf</depend>
 
+  <depend>diagnostic_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>nav_msgs</depend>
   <depend>tf2</depend>
+  <depend>tf2_ros</depend>
   <depend>visualization_msgs</depend>
 
-  <depend condition="$ROS_VERSION == 2">diagnostic_msgs</depend>
-  <depend condition="$ROS_VERSION == 2">geometry_msgs</depend>
   <depend condition="$ROS_VERSION == 2">rcl_interfaces</depend>
 
   <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 1">rospy</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 1">rviz</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 1">xacro</exec_depend>
   <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
   <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
   <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
@@ -48,3 +51,4 @@
   
   <member_of_group condition="$ROS_VERSION == 2">rosidl_interface_packages</member_of_group>
 </package>
+


### PR DESCRIPTION
includes #111 

I ran `catkin_lint --strict -W2 --explain sick_scan_xd` on this package and got quite a number of issues reported:
I tried to fix a few things but then stopped to hear a first feedback

```
sick_scan: CMakeLists.txt: error: unconfigured build_depend on 'rospy'
     * You declare a build dependency on another package but neither
     * call find_package() nor have it listed as catkin component in
     * the find_package(catkin) call.
     * You can ignore this problem with --ignore unconfigured_build_depend
sick_scan: CMakeLists.txt(71): error: variable CMAKE_BUILD_TYPE is overwritten unconditionally
     * If you wish to provide a default value for CMAKE_BUILD_TYPE,
     * make sure that you do not overwrite user preferences. You
     * should guard the set() command with an appropriate if(NOT
     * CMAKE_BUILD_TYPE) block.
     * You can ignore this problem with --ignore cmake_build_type
sick_scan: CMakeLists.txt(95): error: include_directories() needs missing directory 'c:/vcpkg/installed/x64-windows/include'
     * This catkin command processes a particular directory which is
     * missing from the package source folder.
     * You can ignore this problem with --ignore missing_directory
sick_scan: CMakeLists.txt(343): error: link_directories() must not be used for system depends
     * Directories which are added to the search path with
     * link_directories() will not be propagated to dependent
     * packages. Use find_package() or find_library() with the
     * appropriate PATHS or HINTS instead.
     * You can ignore this problem with --ignore external_link_directory
sick_scan: CMakeLists.txt(345): error: include_directories() needs missing directory '${CATKIN_INSTALL_PREFIX}/../msgpack11/include'
sick_scan: CMakeLists.txt(433): error: package 'nav_msgs' must be in CATKIN_DEPENDS in catkin_package()
     * You have a runtime dependency that you must add to the
     * CATKIN_DEPENDS stanza of your catkin_package().
     * You can ignore this problem with --ignore missing_catkin_depend
sick_scan: CMakeLists.txt(433): error: package 'std_msgs' must be in CATKIN_DEPENDS in catkin_package()
sick_scan: CMakeLists.txt(433): error: package 'visualization_msgs' must be in CATKIN_DEPENDS in catkin_package()
sick_scan: CMakeLists.txt(433): error: package 'nav_msgs' must be in CATKIN_DEPENDS in catkin_package()
sick_scan: CMakeLists.txt(433): error: package 'std_msgs' must be in CATKIN_DEPENDS in catkin_package()
sick_scan: CMakeLists.txt(433): error: package 'geometry_msgs' must be in CATKIN_DEPENDS in catkin_package()
sick_scan: package.xml: error: missing build_depend on 'diagnostic_msgs'
     * Your package uses features of another package but you failed to
     * list this dependency in your package.xml
     * You can ignore this problem with --ignore missing_depend
sick_scan: package.xml: error: missing build_depend on 'tf2_ros'
sick_scan: package.xml: error: missing build_depend on 'roslib'
sick_scan: package.xml: error: missing build_depend on 'geometry_msgs'
sick_scan: package.xml: error: missing build_depend on 'geometry_msgs'
sick_scan: package.xml: error: missing build_export_depend on 'geometry_msgs'
sick_scan: error: include paths 'test/emulator/include' and 'test' are ambiguous
     * You have used two include paths where one is a parent of the
     * other. Thus the same headers can be included with two different
     * include paths which may confuse users. It is recommended that
     * you keep your include paths consistent.
     * You can ignore this problem with --ignore ambiguous_include_path
sick_scan: error: include paths 'test/src/sick_scan_xd_api/toojpeg' and 'test' are ambiguous
sick_scan: error: include paths 'include/sick_scan_xd_api' and 'include' are ambiguous
sick_scan: error: include paths 'roswrap/src/include/launchparser' and 'roswrap/src/include' are ambiguous
sick_scan: error: include paths 'include/sick_scan' and 'include' are ambiguous
sick_scan: error: include paths 'include/tinyxml' and 'include' are ambiguous
sick_scan: CMakeLists.txt(83): error: variable CMAKE_CXX_FLAGS is modified
     * You have appended extra data to a critical CMake variable. This
     * might break the build on different systems or affect the global
     * catkin workspace in unintended ways.
     * You can ignore this problem with --ignore critical_var_append
sick_scan: CMakeLists.txt(86): error: environment variables should not be used
     * The behavior of your build should not depend on any environment
     * variables.
     * You can ignore this problem with --ignore env_var
sick_scan: CMakeLists.txt(87): error: environment variables should not be used
sick_scan: CMakeLists.txt(88): error: environment variables should not be used
sick_scan: CMakeLists.txt(89): error: environment variables should not be used
sick_scan: CMakeLists.txt(96): error: use of link_directories() is strongly discouraged
     * Directories which are added to the search path with
     * link_directories() will not be propagated to dependent
     * packages. You should avoid this command or at least be aware
     * that it might not work as expected in dependent packages.
     * You can ignore this problem with --ignore link_directory
sick_scan: CMakeLists.txt(195): error: environment variables should not be used
sick_scan: CMakeLists.txt(196): error: environment variables should not be used
sick_scan: CMakeLists.txt(201): error: duplicate find_package(diagnostic_updater)
     * You called find_package() more than once for a particular
     * package, which is not needed except for very specific, advanced
     * circumstances.
     * You can ignore this problem with --ignore duplicate_find
sick_scan: CMakeLists.txt(202): error: condition '${diagnostic_updater_FOUND}' is ambiguous
     * Historically, the if() command will interpret a single token as
     * a variable name and transparently resolve it if possible.
     * Unquoted variable references like if(${var}) can lead to
     * incorrect results if ${var} resolves to a different variable
     * name. Use if(var) or if("${var}") instead.
     * You can ignore this problem with --ignore ambiguous_condition
sick_scan: CMakeLists.txt(208): error: duplicate find_package(sensor_msgs)
sick_scan: CMakeLists.txt(209): error: duplicate find_package(std_msgs)
sick_scan: CMakeLists.txt(210): error: duplicate find_package(nav_msgs)
sick_scan: CMakeLists.txt(211): error: duplicate find_package(tf2)
sick_scan: CMakeLists.txt(212): error: duplicate find_package(geometry_msgs)
sick_scan: CMakeLists.txt(214): error: duplicate find_package(visualization_msgs)
sick_scan: CMakeLists.txt(340): error: use of link_directories() is strongly discouraged
sick_scan: CMakeLists.txt(345): error: include_directories() uses directory '${CATKIN_INSTALL_PREFIX}/../msgpack11/include' which is not in package
     * This catkin command uses a directory which lies outside of the
     * package source folder. While this may work in your particular
     * setup, you cannot assume file locations in general. Use
     * find_path() to detect external locations insteed.
     * You can ignore this problem with --ignore external_directory
sick_scan: launch/demo_roscon.launch(57): error: launch configuration needs exec_depend on 'rviz'
     * Your package refers to another package in one of its launch
     * files, but you do not have this dependency in your package.xml
     * You can ignore this problem with --ignore launch_depend
sick_scan: launch/rviz/sick_twin_mrs6xxx_tim5xx.launch(17): error: launch configuration needs exec_depend on 'xacro'
sick_scan: launch/sick_tim_5xx_twin.launch(21): error: launch configuration needs exec_depend on 'xacro'
sick_scan: error: package path name '/home/fxm/projects/default/robot_ws/src/mojin_drivers/sick_scan_xd' differs from package name
     * Your package resides in a folder that has a different name than
     * the package itself. This is confusing and might break the
     * assumptions of some tools.
     * You can ignore this problem with --ignore package_path_name
sick_scan: CMakeLists.txt(8): error: global variable 'ENABLE_EMULATOR' should contain project name
     * Global variables and options are stored in the cache. You
     * should prefix your variable names with the project name to
     * avoid name collisions with other packages.
     * You can ignore this problem with --ignore global_var_collision
sick_scan: CMakeLists.txt(11): error: global variable 'ENABLE_EMULATOR' should contain project name
sick_scan: CMakeLists.txt(17): error: global variable 'BUILD_WITH_LDMRS_SUPPORT' should contain project name
sick_scan: CMakeLists.txt(19): error: global variable 'BUILD_WITH_LDMRS_SUPPORT' should contain project name
sick_scan: CMakeLists.txt(21): error: global variable 'BUILD_WITH_LDMRS_SUPPORT' should contain project name
sick_scan: CMakeLists.txt(26): error: global variable 'BUILD_WITH_SCANSEGMENT_XD_SUPPORT' should contain project name
sick_scan: CMakeLists.txt(28): error: global variable 'BUILD_WITH_SCANSEGMENT_XD_SUPPORT' should contain project name
sick_scan: CMakeLists.txt(33): error: global variable 'BUILD_LIB_HIDE_FUNCTIONS' should contain project name
sick_scan: CMakeLists.txt(35): error: global variable 'BUILD_LIB_HIDE_FUNCTIONS' should contain project name
sick_scan: CMakeLists.txt(39): error: global variable 'BUILD_DEBUG_TARGET' should contain project name
sick_scan: CMakeLists.txt(53): error: extra arguments in endif()
     * The catkin manual recommends that endif and other end-of-block
     * statements have no arguments. If you have nested blocks, you
     * should indent them properly instead.
     * You can ignore this problem with --ignore endblock_args
sick_scan: CMakeLists.txt(57): error: global variable 'ENABLE_EMULATOR' should contain project name
sick_scan: CMakeLists.txt(58): error: global variable 'BUILD_WITH_LDMRS_SUPPORT' should contain project name
sick_scan: CMakeLists.txt(59): error: global variable 'BUILD_WITH_SCANSEGMENT_XD_SUPPORT' should contain project name
sick_scan: CMakeLists.txt(60): error: global variable 'BUILD_DEBUG_TARGET' should contain project name
sick_scan: CMakeLists.txt(88): error: extra arguments in endif()
sick_scan: CMakeLists.txt(128): error: list COMPONENTS should be sorted
     * The catkin manual recommends that list element be kept in
     * order.
     * You can ignore this problem with --ignore unsorted_list
sick_scan: CMakeLists.txt(154): error: list FILES should be sorted
sick_scan: CMakeLists.txt(191): error: extra arguments in endif()
sick_scan: CMakeLists.txt(309): error: extra arguments in endif()
sick_scan: CMakeLists.txt(313): error: use ${PROJECT_NAME} instead of 'sick_scan'
     * The catkin manual recommends that you use the ${PROJECT_NAME}
     * variable instead of the literal project name.
     * You can ignore this problem with --ignore literal_project_name
sick_scan: CMakeLists.txt(324): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(329): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(347): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(349): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(367): error: list FILES should be sorted
sick_scan: CMakeLists.txt(425): error: list DEPENDENCIES should be sorted
sick_scan: CMakeLists.txt(433): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(433): error: list CATKIN_DEPENDS should be sorted
sick_scan: CMakeLists.txt(440): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(442): error: line is not indented properly
     * For better readability, each command should be placed on its
     * own line. if() and foreach() bodies should be indented by one
     * or more extra spaces.
     * You can ignore this problem with --ignore indentation
sick_scan: CMakeLists.txt(451): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(495): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(495): error: list of source files should be sorted
sick_scan: CMakeLists.txt(497): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(497): error: list of source files should be sorted
sick_scan: CMakeLists.txt(499): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(503): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(508): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(509): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(513): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(542): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(551): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(597): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(597): error: list of source files should be sorted
sick_scan: CMakeLists.txt(599): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(599): error: list of source files should be sorted
sick_scan: CMakeLists.txt(603): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(606): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(612): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(626): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(655): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(656): error: line is not indented properly
sick_scan: CMakeLists.txt(656): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(660): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(661): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(665): error: extra arguments in endif()
sick_scan: CMakeLists.txt(668): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(668): error: list of source files should be sorted
sick_scan: CMakeLists.txt(674): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(676): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(677): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(685): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(686): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(693): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(699): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(704): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(721): error: extra arguments in endif()
sick_scan: CMakeLists.txt(724): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(727): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(734): error: extra arguments in endif()
sick_scan: CMakeLists.txt(740): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(740): error: list of source files should be sorted
sick_scan: CMakeLists.txt(760): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(766): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(769): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(778): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(793): error: list of source files should be sorted
sick_scan: CMakeLists.txt(799): error: use ${PROJECT_NAME} instead of 'sick_scan'
sick_scan: CMakeLists.txt(803): error: extra arguments in endif()
sick_scan: package.xml: error: package description starts with boilerplate 'ROS 1 and 2'
     * Your package description starts with a number of typical filler
     * words which do not actually describe the contents of your
     * package. Typically, you can simply delete these words from the
     * description, and it will still make sense and be much more
     * concise.
     * You can ignore this problem with --ignore description_boilerplate
catkin_lint: checked 1 packages and found 126 problems
```