### PR TITLE
fix: galactic build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -643,7 +643,7 @@ if(ROS_VERSION EQUAL 2)
         ${LDMRS_TARGET_DEPENDENCIES}
     )
 
-    if(WIN32 OR EXISTS "/opt/ros/eloquent" OR EXISTS "/opt/ros/foxy") # rosidl_typesupport for ROS2 eloquent and foxy
+    if(WIN32 OR EXISTS "/opt/ros/eloquent" OR EXISTS "/opt/ros/foxy" OR EXISTS "/opt/ros/galactic") # rosidl_typesupport for ROS2 eloquent and foxy
         rosidl_target_interfaces(sick_scan_lib ${PROJECT_NAME} "rosidl_typesupport_cpp")
 	rosidl_target_interfaces(sick_scan_shared_lib ${PROJECT_NAME} "rosidl_typesupport_cpp")
         # rosidl_target_interfaces(sick_generic_caller ${PROJECT_NAME} "rosidl_typesupport_cpp")


### PR DESCRIPTION
Build fails on Linux ROS2 galactic with the following CMake error:

--- stderr: sick_scan                           
CMake Error at CMakeLists.txt:651 (rosidl_get_typesupport_target):
  Unknown CMake command "rosidl_get_typesupport_target".

Simple fix help for building on ROS2 galactic.