### PR TITLE
Fix missing diagnostic_updater dependency for ROS2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,13 +19,13 @@
   <build_depend condition="$ROS_VERSION == 1">message_runtime</build_depend>
   <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
 
-  <depend condition="$ROS_VERSION == 1">diagnostic_updater</depend>
   <depend condition="$ROS_VERSION == 1">dynamic_reconfigure</depend>
   <depend condition="$BUILD_WITH_LDMRS_SUPPORT == True">libsick_ldmrs</depend>
   <depend condition="$ROS_VERSION == 1">roscpp</depend>
   <depend condition="$ROS_VERSION == 1">rospy</depend>
   <depend condition="$ROS_VERSION == 1">tf</depend>
 
+  <depend>diagnostic_updater</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>nav_msgs</depend>


### PR DESCRIPTION
This fixes a build issue found on ROS2, since the diagnostic_updater package may not be available in a basic ROS2 install.