### PR TITLE
make MIN MAX defines more unique to avoid "error: invalid use of ‘::'"

### DIFF
--- a/driver/src/sick_generic_monitoring.cpp
+++ b/driver/src/sick_generic_monitoring.cpp
@@ -89,7 +89,7 @@ sick_scan::ExitCode sick_scan::SickScanMonitor::checkState(NodeRunState runState
   {
     double read_timeout = 0.001 * scanner->getReadTimeOutInMs();                          // current read timeout in seconds
     uint64_t nanosec_last_tcp_msg = scanner->getNanosecTimestampLastTcpMessageReceived(); // timestamp in nanoseconds of the last received tcp message (or 0 if no message received)
-    uint64_t nanosec_now = MAX(nanosec_last_tcp_msg, rosNanosecTimestampNow());      // timestamp in nanoseconds now
+    uint64_t nanosec_now = MAX_AB(nanosec_last_tcp_msg, rosNanosecTimestampNow());      // timestamp in nanoseconds now
     // ROS_INFO_STREAM("SickScanMonitor::checkState(): runState=scanner_run, last_tcp_msg=" << (1.0e-9 * nanosec_last_tcp_msg) << " sec, scanner->numberOfDatagramInInputFifo()=" << scanner->numberOfDatagramInInputFifo());
 
     if(nanosec_last_tcp_msg == 0)

--- a/driver/src/sick_scan_common.cpp
+++ b/driver/src/sick_scan_common.cpp
@@ -3928,7 +3928,7 @@ namespace sick_scan
       {
         return ExitSuccess;
       }
-      ROS_DEBUG_STREAM("SickScanCommon::loopOnce: received " << actual_length << " byte data " << DataDumper::binDataToAsciiString(&receiveBuffer[0], MIN(32, actual_length)) << " ... ");
+      ROS_DEBUG_STREAM("SickScanCommon::loopOnce: received " << actual_length << " byte data " << DataDumper::binDataToAsciiString(&receiveBuffer[0], MIN_AB(32, actual_length)) << " ... ");
 
       if (publish_datagram_)
       {
@@ -4140,7 +4140,7 @@ namespace sick_scan
                 {
                   // warn about unexpected message and ignore all non-scandata messages
                   ROS_WARN_STREAM("## WARNING in SickScanCommon::loopOnce(): " << actual_length << " byte message ignored ("
-                    << DataDumper::binDataToAsciiString(&receiveBuffer[0], MIN(actual_length, 64)) << (actual_length>64?"...":"") << ")");
+                    << DataDumper::binDataToAsciiString(&receiveBuffer[0], MIN_AB(actual_length, 64)) << (actual_length>64?"...":"") << ")");
                 }
                 else
                 {
@@ -4398,7 +4398,7 @@ namespace sick_scan
                   // If msg.intensities[j] < min_intensity, then set msg.ranges[j] to inf according to https://github.com/SICKAG/sick_scan/issues/131
                   if(m_min_intensity > 0) // Set range of LaserScan messages to infinity, if intensity < min_intensity (default: 0)
                   {
-                    for (int j = 0, j_max = (int)MIN(msg.ranges.size(), msg.intensities.size()); j < j_max; j++)
+                    for (int j = 0, j_max = (int)MIN_AB(msg.ranges.size(), msg.intensities.size()); j < j_max; j++)
                     {
                       if(msg.intensities[j] < m_min_intensity)
                       {
@@ -4505,7 +4505,7 @@ namespace sick_scan
 
               size_t rangeNumAllEchos = rangeTmp.size(); // rangeTmp.size() := number of range values in all echos (max. 5 echos)
               size_t rangeNumAllEchosCloud = cloud_.height * cloud_.width; // number of points allocated in the point cloud
-              rangeNumAllEchos = MIN(rangeNumAllEchos, rangeNumAllEchosCloud); // limit number of range values (issue #49): if no echofilter was set, the number of echos can exceed the expected echos
+              rangeNumAllEchos = MIN_AB(rangeNumAllEchos, rangeNumAllEchosCloud); // limit number of range values (issue #49): if no echofilter was set, the number of echos can exceed the expected echos
               size_t rangeNum = rangeNumAllEchos / numValidEchos;
               // ROS_INFO_STREAM("numValidEchos=" << numValidEchos << ", numEchos=" << numEchos << ", cloud_.height * cloud_.width=" << cloud_.height * cloud_.width << ", rangeNum=" << rangeNum);
 
@@ -4631,7 +4631,7 @@ namespace sick_scan
                   }
                   angle += msg.angle_increment;
                 }
-                rangeNumPointcloudAllEchos = MAX(rangeNumPointcloudAllEchos, rangeNumPointcloudCurEcho);
+                rangeNumPointcloudAllEchos = MAX_AB(rangeNumPointcloudAllEchos, rangeNumPointcloudCurEcho);
 
                 // Publish
                 //static int cnt = 0;
@@ -5534,8 +5534,8 @@ namespace sick_scan
           scan_layer_activated.push_back(arg_val);
           if (arg_val > 0)
           {
-            first_active_layer = MIN(layer, first_active_layer);
-            last_active_layer = MAX(layer, last_active_layer);
+            first_active_layer = MIN_AB(layer, first_active_layer);
+            last_active_layer = MAX_AB(layer, last_active_layer);
           }
         }
       }

--- a/driver/src/sick_scan_marker.cpp
+++ b/driver/src/sick_scan_marker.cpp
@@ -142,7 +142,7 @@ void sick_scan::SickScanMarker::updateMarker(sick_scan_msg::LIDoutputstateMsg& m
         m_scan_mon_fieldset = fieldMon->getActiveFieldset();
         ROS_DEBUG_STREAM("SickScanMarker: active_fieldset = " << fieldMon->getActiveFieldset());
     }
-    int num_devices = (int)MIN(msg.output_count.size(), msg.output_state.size());
+    int num_devices = (int)MIN_AB(msg.output_count.size(), msg.output_state.size());
     std::vector<std::string> output_state(num_devices);
     std::vector<std::string> output_count(num_devices);
     std::vector<ros_std_msgs::ColorRGBA> output_colors(num_devices);
@@ -278,9 +278,9 @@ std::vector<ros_visualization_msgs::Marker> sick_scan::SickScanMarker::createMon
         const sick_scan::SickScanMonField& mon_field = m_scan_mon_fields[field_idx];
         SickScanMonFieldType field_typ = mon_field.fieldType();
         if(field_typ == MON_FIELD_DYNAMIC) // dynamic fields have two rectangle (first rectangle for v = max, second rectangle for v = 0)
-            nr_triangles += 2 * MAX(0, mon_field.getPointCount()/2 - 2); // 3 points: 1 triangle, 4 points: 3 triangles, and so on
+            nr_triangles += 2 * MAX_AB(0, mon_field.getPointCount()/2 - 2); // 3 points: 1 triangle, 4 points: 3 triangles, and so on
         else
-            nr_triangles += MAX(0, mon_field.getPointCount() - 2); // 3 points: 1 triangle, 4 points: 3 triangles, and so on
+            nr_triangles += MAX_AB(0, mon_field.getPointCount() - 2); // 3 points: 1 triangle, 4 points: 3 triangles, and so on
         // std::map<SickScanMonFieldType,std::string> field_type_str = { {MON_FIELD_RADIAL, "MON_FIELD_RADIAL"}, {MON_FIELD_RECTANGLE, "MON_FIELD_RECTANGLE"}, {MON_FIELD_SEGMENTED, "MON_FIELD_SEGMENTED"}, {MON_FIELD_DYNAMIC, "MON_FIELD_DYNAMIC"} };
         // ROS_INFO_STREAM("sick_scan::SickScanMarker::createMonFieldMarker(): field[" << field_info_idx << "]: type=" << field_type_str[field_typ] << ", " << (mon_field.getPointCount()) << " points");
     }

--- a/include/sick_scan/sick_generic_callback.h
+++ b/include/sick_scan/sick_generic_callback.h
@@ -223,7 +223,7 @@ namespace sick_scan
 
         bool waitForNextMessage(MsgType& msg, double timeout_sec)
         {
-            uint64_t timeout_microsec = MAX((uint64_t)(1), (uint64_t)(timeout_sec * 1.0e6));
+            uint64_t timeout_microsec = MAX_AB((uint64_t)(1), (uint64_t)(timeout_sec * 1.0e6));
             std::chrono::system_clock::time_point wait_end_time = std::chrono::system_clock::now() + std::chrono::microseconds(timeout_microsec);
             std::unique_lock<std::mutex> lock(m_message_mutex);
             m_message_valid = false;

--- a/include/sick_scan/sick_ros_wrapper.h
+++ b/include/sick_scan/sick_ros_wrapper.h
@@ -88,11 +88,11 @@
 #endif
 
 #if defined _MSC_VER
-#define MAX(a,b) (((a) > (b)) ? (a) : (b))
-#define MIN(a,b) (((a) < (b)) ? (a) : (b))
+#define MAX_AB(a,b) (((a) > (b)) ? (a) : (b))
+#define MIN_AB(a,b) (((a) < (b)) ? (a) : (b))
 #else
-#define MAX std::max
-#define MIN std::min
+#define MAX_AB std::max
+#define MIN_AB std::min
 #endif
 
 template <typename T> std::string paramToString(const std::vector<T>& param_value)


### PR DESCRIPTION
I didn't have an issue building this locally, but inside a github action it wouldn't build without changing the name of MIN() & MAX() (and some help from https://stackoverflow.com/questions/44596168/c-error-invalid-use-of-for-stdcout)

```
/sick_scan_xd/include/sick_scan/sick_ros_wrapper.h:95:18: error: invalid use of ‘::’```

