### PR TITLE
Change the calling convention in sick_scan_xd_api_wrapper.c from __stdcall to __cdecl

### DIFF
--- a/test/src/sick_scan_xd_api/sick_scan_xd_api_wrapper.c
+++ b/test/src/sick_scan_xd_api/sick_scan_xd_api_wrapper.c
@@ -37,7 +37,7 @@ static void* GetProcAddress(HINSTANCE hLib, const char* szFunctionName)
 static HINSTANCE hinstLib = NULL;
 
 #ifdef WIN32
-typedef SickScanApiHandle(__stdcall* SickScanApiCreate_PROCTYPE)(int argc, char** argv);
+typedef SickScanApiHandle(__cdecl* SickScanApiCreate_PROCTYPE)(int argc, char** argv);
 static SickScanApiCreate_PROCTYPE ptSickScanApiCreate = 0;
 #else
 typedef SickScanApiHandle(*SickScanApiCreate_PROCTYPE)(int argc, char** argv);


### PR DESCRIPTION
This is a proposed solution to issue #310 

Changing the calling convention from __stdcall to __cdecl here enables the library to operate in 32-bit mode. Since the .dll is also compiled with __cdecl as the calling convention this makes sense. 

However, we weren't able to test if the library still works fine with real hardware though.