### PR TITLE
add missing cstdint includes

### DIFF
--- a/include/sick_scan/dataDumper.h
+++ b/include/sick_scan/dataDumper.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #define DEBUG_DUMP_ENABLED 0
 //#define DEBUG_DUMP_TO_CONSOLE_ENABLED

--- a/include/sick_scan/softwarePLL.h
+++ b/include/sick_scan/softwarePLL.h
@@ -16,6 +16,7 @@
 #include <cstdlib>
 #include <iomanip>
 #include <ctime>
+#include <cstdint>
 
 class SoftwarePLL
 {

--- a/include/sick_scansegment_xd/msgpack11/msgpack11.hpp
+++ b/include/sick_scansegment_xd/msgpack11/msgpack11.hpp
@@ -8,7 +8,7 @@
 #include <istream>
 #include <ostream>
 #include <sstream>
-
+#include <cstdint>
 
 #ifdef _MSC_VER
     #if _MSC_VER <= 1800 // VS 2013


### PR DESCRIPTION
Hi,
first PR in here, hope that's fine that way.

We had issues compiling the sensor driver with Ubuntu 24.04 and ROS jazzy.
It seems like there were some cstdint includes missing. Errors have been that it couldn't resolve std::utint64_t, etc.

Feel free to modify or fix it another way. :)