### PR TITLE
Update urdf to be used in ROS2 with Gazebo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -911,7 +911,7 @@ if(ROS_VERSION EQUAL 2)
     endif()
     install(TARGETS sick_generic_caller DESTINATION lib/${PROJECT_NAME})
     install(TARGETS ${PROJECT_NAME}_lib ${PROJECT_NAME}_shared_lib DESTINATION lib)
-    install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+    install(DIRECTORY launch urdf meshes DESTINATION share/${PROJECT_NAME})
         
     ament_package()        
 endif()

--- a/urdf/example.urdf.xacro
+++ b/urdf/example.urdf.xacro
@@ -5,7 +5,7 @@
   xmlns:xacro="http://ros.org/wiki/xacro"
   name="sick_scan">
 
-  <xacro:include filename="$(find sick_scan)/urdf/sick_scan.urdf.xacro" />
+  <xacro:include filename="$(find sick_scan_xd)/urdf/sick_scan.urdf.xacro" />
 
   <xacro:sick_tim_5xx name="laser" ros_topic="scan" />
   <xacro:sick_tim_1xxx name="laser" ros_topic="scan" />

--- a/urdf/sick_lms1xx.urdf.xacro
+++ b/urdf/sick_lms1xx.urdf.xacro
@@ -121,11 +121,6 @@
           </ray>
           <always_on>1</always_on>
           <visualize>false</visualize>
-          <plugin
-            filename="gz-sim-sensors-system"
-            name="gz::sim::systems::Sensors">
-            <render_engine>ogre2</render_engine>
-          </plugin>
         </sensor>
       </xacro:if>
     </gazebo>

--- a/urdf/sick_lms1xx.urdf.xacro
+++ b/urdf/sick_lms1xx.urdf.xacro
@@ -55,36 +55,79 @@
   <xacro:macro name="sick_lms_1_laser_gazebo_v0" params="name link ros_topic update_rate min_angle max_angle min_range max_range gaussian_noise">
     <gazebo reference="${link}">
       <material value="Gazebo/Blue" />
-      <sensor type="ray" name="${name}">
-        <always_on>true</always_on>
-        <update_rate>${update_rate}</update_rate>
-        <pose>0 0 0 0 0 0</pose>
-        <visualize>false</visualize>
-        <ray>
-          <scan>
-            <horizontal>
-              <samples>540</samples>
-              <resolution>1</resolution>
-              <min_angle>${min_angle}</min_angle>
-              <max_angle>${max_angle}</max_angle>
-            </horizontal>
-          </scan>
-          <range>
-            <min>${min_range}</min>
-            <max>${max_range}</max>
-            <resolution>0.01</resolution>
-          </range>
-          <noise>
-            <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>${gaussian_noise}</stddev>
-          </noise>
-        </ray>
-        <plugin name="gazebo_ros_${name}_controller" filename="libgazebo_ros_laser.so">
-          <topicName>${ros_topic}</topicName>
-          <frameName>${link}</frameName>
-        </plugin>
-      </sensor>
+      <xacro:if value="${$(env ROS_VERSION) == 1}">
+        <sensor type="ray" name="${name}">
+          <always_on>true</always_on>
+          <update_rate>${update_rate}</update_rate>
+          <pose>0 0 0 0 0 0</pose>
+          <visualize>false</visualize>
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>540</samples>
+                <resolution>1</resolution>
+                <min_angle>${min_angle}</min_angle>
+                <max_angle>${max_angle}</max_angle>
+              </horizontal>
+            </scan>
+            <range>
+              <min>${min_range}</min>
+              <max>${max_range}</max>
+              <resolution>0.01</resolution>
+            </range>
+            <noise>
+              <type>gaussian</type>
+              <mean>0.0</mean>
+              <stddev>${gaussian_noise}</stddev>
+            </noise>
+          </ray>
+          <plugin name="gazebo_ros_${name}_controller" filename="libgazebo_ros_laser.so">
+            <topicName>${ros_topic}</topicName>
+            <frameName>${link}</frameName>
+          </plugin>
+        </sensor>
+      </xacro:if>
+      <xacro:if value="${$(env ROS_VERSION) == 2}">
+        <sensor type="gpu_lidar" name="${name}">
+          <pose>0 0 0 0 0 0</pose>
+          <topic>${ros_topic}</topic>
+          <frame_id>${name}</frame_id>
+          <update_rate>${update_rate}</update_rate>
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>540</samples>
+                <resolution>1</resolution>
+                <min_angle>${min_angle}</min_angle>
+                <max_angle>${max_angle}</max_angle>
+              </horizontal>
+              <vertical>
+                <samples>1</samples>
+                <resolution>0.01</resolution>
+                <min_angle>0</min_angle>
+                <max_angle>0</max_angle>
+              </vertical>
+            </scan>
+            <range>
+              <min>${min_range}</min>
+              <max>${max_range}</max>
+              <resolution>0.01</resolution>
+            </range>
+            <noise>
+              <type>gaussian</type>
+              <mean>0.0</mean>
+              <stddev>${gaussian_noise}</stddev>
+            </noise>
+          </ray>
+          <always_on>1</always_on>
+          <visualize>false</visualize>
+          <plugin
+            filename="gz-sim-sensors-system"
+            name="gz::sim::systems::Sensors">
+            <render_engine>ogre2</render_engine>
+          </plugin>
+        </sensor>
+      </xacro:if>
     </gazebo>
   </xacro:macro>
 </robot>

--- a/urdf/sick_lms1xx.urdf.xacro
+++ b/urdf/sick_lms1xx.urdf.xacro
@@ -14,7 +14,7 @@
     <link name="${name}_mount_link">
       <visual>
         <geometry>
-          <mesh filename="package://sick_scan/meshes/LMS1xx_small.dae" />
+          <mesh filename="package://sick_scan_xd/meshes/LMS1xx_small.dae" />
         </geometry>
         <material name="blue" >
           <color rgba="0 0 1 1" />
@@ -22,7 +22,7 @@
       </visual>
       <collision>
         <geometry>
-          <mesh filename="package://sick_scan/meshes/LMS1xx_collision.stl" />
+          <mesh filename="package://sick_scan_xd/meshes/LMS1xx_collision.stl" />
         </geometry>
       </collision>
       <inertial>

--- a/urdf/sick_lms5xx.urdf.xacro
+++ b/urdf/sick_lms5xx.urdf.xacro
@@ -121,11 +121,6 @@
           </ray>
           <always_on>1</always_on>
           <visualize>false</visualize>
-          <plugin
-            filename="gz-sim-sensors-system"
-            name="gz::sim::systems::Sensors">
-            <render_engine>ogre2</render_engine>
-          </plugin>
         </sensor>
       </xacro:if>
     </gazebo>

--- a/urdf/sick_lms5xx.urdf.xacro
+++ b/urdf/sick_lms5xx.urdf.xacro
@@ -55,36 +55,79 @@
   <xacro:macro name="sick_lms_5_laser_gazebo_v0" params="name link ros_topic update_rate min_angle max_angle min_range max_range gaussian_noise">
     <gazebo reference="${link}">
       <material value="Gazebo/Blue" />
-      <sensor type="ray" name="${name}">
-        <always_on>true</always_on>
-        <update_rate>${update_rate}</update_rate>
-        <pose>0 0 0 0 0 0</pose>
-        <visualize>false</visualize>
-        <ray>
-          <scan>
-            <horizontal>
-              <samples>380</samples>
-              <resolution>1</resolution>
-              <min_angle>${min_angle}</min_angle>
-              <max_angle>${max_angle}</max_angle>
-            </horizontal>
-          </scan>
-          <range>
-            <min>${min_range}</min>
-            <max>${max_range}</max>
-            <resolution>0.01</resolution>
-          </range>
-          <noise>
-            <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>${gaussian_noise}</stddev>
-          </noise>
-        </ray>
-        <plugin name="gazebo_ros_${name}_controller" filename="libgazebo_ros_laser.so">
-          <topicName>${ros_topic}</topicName>
-          <frameName>${link}</frameName>
-        </plugin>
-      </sensor>
+      <xacro:if value="${$(env ROS_VERSION) == 1}">
+        <sensor type="ray" name="${name}">
+          <always_on>true</always_on>
+          <update_rate>${update_rate}</update_rate>
+          <pose>0 0 0 0 0 0</pose>
+          <visualize>false</visualize>
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>380</samples>
+                <resolution>1</resolution>
+                <min_angle>${min_angle}</min_angle>
+                <max_angle>${max_angle}</max_angle>
+              </horizontal>
+            </scan>
+            <range>
+              <min>${min_range}</min>
+              <max>${max_range}</max>
+              <resolution>0.01</resolution>
+            </range>
+            <noise>
+              <type>gaussian</type>
+              <mean>0.0</mean>
+              <stddev>${gaussian_noise}</stddev>
+            </noise>
+          </ray>
+          <plugin name="gazebo_ros_${name}_controller" filename="libgazebo_ros_laser.so">
+            <topicName>${ros_topic}</topicName>
+            <frameName>${link}</frameName>
+          </plugin>
+        </sensor>
+      </xacro:if>
+      <xacro:if value="${$(env ROS_VERSION) == 2}">
+        <sensor type="gpu_lidar" name="${name}">
+          <pose>0 0 0 0 0 0</pose>
+          <topic>${ros_topic}</topic>
+          <frame_id>${name}</frame_id>
+          <update_rate>${update_rate}</update_rate>
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>380</samples>
+                <resolution>1</resolution>
+                <min_angle>${min_angle}</min_angle>
+                <max_angle>${max_angle}</max_angle>
+              </horizontal>
+              <vertical>
+                <samples>1</samples>
+                <resolution>0.01</resolution>
+                <min_angle>0</min_angle>
+                <max_angle>0</max_angle>
+              </vertical>
+            </scan>
+            <range>
+              <min>${min_range}</min>
+              <max>${max_range}</max>
+              <resolution>0.01</resolution>
+            </range>
+            <noise>
+              <type>gaussian</type>
+              <mean>0.0</mean>
+              <stddev>${gaussian_noise}</stddev>
+            </noise>
+          </ray>
+          <always_on>1</always_on>
+          <visualize>false</visualize>
+          <plugin
+            filename="gz-sim-sensors-system"
+            name="gz::sim::systems::Sensors">
+            <render_engine>ogre2</render_engine>
+          </plugin>
+        </sensor>
+      </xacro:if>
     </gazebo>
   </xacro:macro>
 </robot>

--- a/urdf/sick_lms5xx.urdf.xacro
+++ b/urdf/sick_lms5xx.urdf.xacro
@@ -15,7 +15,7 @@
     <link name="${name}_mount_link">
       <visual>
         <geometry>
-          <mesh filename="package://sick_scan/meshes/LMS5xx_small.dae" />
+          <mesh filename="package://sick_scan_xd/meshes/LMS5xx_small.dae" />
         </geometry>
         <material name="blue" >
           <color rgba="0 0 1 1" />
@@ -23,7 +23,7 @@
       </visual>
       <collision>
         <geometry>
-          <mesh filename="package://sick_scan/meshes/LMS5xx_collision.stl" />
+          <mesh filename="package://sick_scan_xd/meshes/LMS5xx_collision.stl" />
         </geometry>
       </collision>
       <inertial>

--- a/urdf/sick_scan.urdf.xacro
+++ b/urdf/sick_scan.urdf.xacro
@@ -118,6 +118,7 @@
         <sensor type="gpu_lidar" name="${name}">
           <pose>0 0 0 0 0 0</pose>
           <topic>${ros_topic}</topic>
+          <frame_id>${name}</frame_id>
           <update_rate>${update_rate}</update_rate>
           <ray>
             <scan>

--- a/urdf/sick_scan.urdf.xacro
+++ b/urdf/sick_scan.urdf.xacro
@@ -82,36 +82,78 @@
   <xacro:macro name="sick_tim_laser_gazebo_v0" params="name link ros_topic update_rate min_angle max_angle min_range max_range gaussian_noise samples">
     <gazebo reference="${link}">
       <material value="Gazebo/Blue" />
-      <sensor type="ray" name="${name}">
-        <always_on>true</always_on>
-        <update_rate>${update_rate}</update_rate>
-        <pose>0 0 0 0 0 0</pose>
-        <visualize>false</visualize>
-        <ray>
-          <scan>
-            <horizontal>
-              <samples>${samples}</samples>
-              <resolution>1</resolution>
-              <min_angle>${min_angle}</min_angle>
-              <max_angle>${max_angle}</max_angle>
-            </horizontal>
-          </scan>
-          <range>
-            <min>${min_range}</min>
-            <max>${max_range}</max>
-            <resolution>0.01</resolution>
-          </range>
-          <noise>
-            <type>gaussian</type>
-            <mean>0.0</mean>
-            <stddev>${gaussian_noise}</stddev>
-          </noise>
-        </ray>
-        <plugin name="gazebo_ros_${name}_controller" filename="libgazebo_ros_laser.so">
-          <topicName>${ros_topic}</topicName>
-          <frameName>${link}</frameName>
-        </plugin>
-      </sensor>
+      <xacro:if value="${$(env ROS_VERSION) == 1}">
+        <sensor type="ray" name="${name}">
+          <always_on>true</always_on>
+          <update_rate>${update_rate}</update_rate>
+          <pose>0 0 0 0 0 0</pose>
+          <visualize>false</visualize>
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>${samples}</samples>
+                <resolution>1</resolution>
+                <min_angle>${min_angle}</min_angle>
+                <max_angle>${max_angle}</max_angle>
+              </horizontal>
+            </scan>
+            <range>
+              <min>${min_range}</min>
+              <max>${max_range}</max>
+              <resolution>0.01</resolution>
+            </range>
+            <noise>
+              <type>gaussian</type>
+              <mean>0.0</mean>
+              <stddev>${gaussian_noise}</stddev>
+            </noise>
+          </ray>
+          <plugin name="gazebo_ros_${name}_controller" filename="libgazebo_ros_laser.so">
+            <topicName>${ros_topic}</topicName>
+            <frameName>${link}</frameName>
+          </plugin>
+        </sensor>
+      </xacro:if>
+      <xacro:if value="${$(env ROS_VERSION) == 2}">
+        <sensor type="gpu_lidar" name="${name}">
+          <pose>0 0 0 0 0 0</pose>
+          <topic>${ros_topic}</topic>
+          <update_rate>${update_rate}</update_rate>
+          <ray>
+            <scan>
+              <horizontal>
+                <samples>${samples}</samples>
+                <resolution>1</resolution>
+                <min_angle>${min_angle}</min_angle>
+                <max_angle>${max_angle}</max_angle>
+              </horizontal>
+              <vertical>
+                <samples>1</samples>
+                <resolution>0.01</resolution>
+                <min_angle>0</min_angle>
+                <max_angle>0</max_angle>
+              </vertical>
+            </scan>
+            <range>
+              <min>${min_range}</min>
+              <max>${max_range}</max>
+              <resolution>0.01</resolution>
+            </range>
+            <noise>
+              <type>gaussian</type>
+              <mean>0.0</mean>
+              <stddev>${gaussian_noise}</stddev>
+            </noise>
+          </ray>
+          <always_on>1</always_on>
+          <visualize>false</visualize>
+          <plugin
+            filename="gz-sim-sensors-system"
+            name="gz::sim::systems::Sensors">
+            <render_engine>ogre2</render_engine>
+          </plugin>
+        </sensor>
+      </xacro:if>
     </gazebo>
   </xacro:macro>
 </robot>

--- a/urdf/sick_scan.urdf.xacro
+++ b/urdf/sick_scan.urdf.xacro
@@ -148,11 +148,6 @@
           </ray>
           <always_on>1</always_on>
           <visualize>false</visualize>
-          <plugin
-            filename="gz-sim-sensors-system"
-            name="gz::sim::systems::Sensors">
-            <render_engine>ogre2</render_engine>
-          </plugin>
         </sensor>
       </xacro:if>
     </gazebo>

--- a/urdf/sick_scan.urdf.xacro
+++ b/urdf/sick_scan.urdf.xacro
@@ -9,7 +9,7 @@
       length="0.06" width="0.06" height="0.079" mass="0.150" z_offset="0.05595"
       min_angle="${min_angle}" max_angle="${max_angle}"
       min_range="0.05" max_range="4.0" gaussian_noise="${gaussian_noise}" samples="${samples}"
-      mesh="package://sick_scan/meshes/sick_tim_5xx.stl" />
+      mesh="package://sick_scan_xd/meshes/sick_tim_5xx.stl" />
   </xacro:macro>
 
   <xacro:macro name="sick_tim_56x" params="name ros_topic min_angle:=-2.357 max_angle:=2.357 gaussian_noise:=0.01 samples:=811">
@@ -17,7 +17,7 @@
       length="0.06" width="0.06" height="0.079" mass="0.150" z_offset="0.05595"
       min_angle="${min_angle}" max_angle="${max_angle}"
       min_range="0.05" max_range="10.0" gaussian_noise="${gaussian_noise}" samples="${samples}"
-      mesh="package://sick_scan/meshes/sick_tim_5xx.stl" />
+      mesh="package://sick_scan_xd/meshes/sick_tim_5xx.stl" />
   </xacro:macro>
 
   <xacro:macro name="sick_tim_57x" params="name ros_topic min_angle:=-2.357 max_angle:=2.357 gaussian_noise:=0.01 samples:=811">
@@ -25,7 +25,7 @@
       length="0.06" width="0.06" height="0.079" mass="0.150" z_offset="0.05595"
       min_angle="${min_angle}" max_angle="${max_angle}"
       min_range="0.05" max_range="25.0" gaussian_noise="${gaussian_noise}" samples="${samples}"
-      mesh="package://sick_scan/meshes/sick_tim_5xx.stl" />
+      mesh="package://sick_scan_xd/meshes/sick_tim_5xx.stl" />
   </xacro:macro>
 
   <xacro:macro name="sick_tim_1xxx" params="name ros_topic min_angle:=-2.357 max_angle:=2.357 gaussian_noise:=0.015 samples:=271">
@@ -33,7 +33,7 @@
       length="0.06" width="0.06" height="0.079" mass="0.150" z_offset="0.05595"
       min_angle="${min_angle}" max_angle="${max_angle}"
       min_range="0.05" max_range="4.0" gaussian_noise="${gaussian_noise}" samples="${samples}"
-      mesh="package://sick_scan/meshes/sick_tim_1xxx.stl" />
+      mesh="package://sick_scan_xd/meshes/sick_tim_1xxx.stl" />
   </xacro:macro>
 
   <xacro:macro name="sick_tim" params="name ros_topic length width height mass z_offset min_angle max_angle min_range max_range gaussian_noise samples mesh">


### PR DESCRIPTION
- [x] Install the mesh and urdf directory in ROS2
- [x] Fixed filenames for all meshes in the urdf 
  - I think this was broken on ROS1 as well, because of the package name change from `sick_scan` to `sick_scan_xd`
- Add new `<sensor>` for Gazebo enabled on `$(env ROS_VERSION) == 2`
  - [x] Fixed for all SICK Tim xacro macros
  - [x] Fixed for LMS1xx
  - [x] Fixed for LMS5xx

