### PR TITLE
remove force update ros2 

### DIFF
--- a/driver/src/sick_scan_common.cpp
+++ b/driver/src/sick_scan_common.cpp
@@ -4359,6 +4359,16 @@ namespace sick_scan_xd
   */
   int SickScanCommon::loopOnce(rosNodePtr nh)
   {
+    //static int cnt = 0;
+#ifdef USE_DIAGNOSTIC_UPDATER
+    if(diagnostics_)
+    {
+#if __ROS_VERSION == 1 // ROS 1
+      diagnostics_->update();
+#endif
+    }
+#endif
+
     unsigned char receiveBuffer[65536];
     int actual_length = 0;
     static unsigned int iteration_count = 0;

--- a/driver/src/sick_scan_common.cpp
+++ b/driver/src/sick_scan_common.cpp
@@ -4359,18 +4359,6 @@ namespace sick_scan_xd
   */
   int SickScanCommon::loopOnce(rosNodePtr nh)
   {
-    //static int cnt = 0;
-#ifdef USE_DIAGNOSTIC_UPDATER
-    if(diagnostics_)
-    {
-#if __ROS_VERSION == 2 // ROS 2
-      diagnostics_->force_update();
-#else
-      diagnostics_->update();
-#endif
-    }
-#endif
-
     unsigned char receiveBuffer[65536];
     int actual_length = 0;
     static unsigned int iteration_count = 0;


### PR DESCRIPTION
Force update is unnecessary, diagnostic updater already updates at 1 Hz by default in ros2
Calling force update in LoopOnce() can result in "No data since last update." warning because it messes up the frequency check
