### PR TITLE
Added more relaxed check that cloud is polar or cartesian.

### DIFF
--- a/driver/src/sick_scansegment_xd/ros_msgpack_publisher.cpp
+++ b/driver/src/sick_scansegment_xd/ros_msgpack_publisher.cpp
@@ -470,24 +470,24 @@ std::string sick_scansegment_xd::RosMsgpackPublisher::printCoverageTable(const s
   return s.str();
 }
 
+bool sick_scansegment_xd::RosMsgpackPublisher::hasPointcloudRequiredFields(const PointCloud2Msg& pointcloud_msg, const std::unordered_set<std::string>& required_fields) const {
+	const size_t numRequiredFields = required_fields.size();
+	int found = 0;
+	for (const auto& field : pointcloud_msg.fields) {
+		if (required_fields.find(field.name) != required_fields.end()) {
+			found++;
+		}
+	}
+	return (found == numRequiredFields);
+}
+
 /** Shortcut to publish a PointCloud2Msg */
 void sick_scansegment_xd::RosMsgpackPublisher::publishPointCloud2Msg(rosNodePtr node, PointCloud2MsgPublisher& publisher, PointCloud2Msg& pointcloud_msg, int32_t num_echos, int32_t segment_idx, int coordinate_notation, const std::string& topic)
 {
 
   bool isCartesian = (coordinate_notation == 0);
   if (!isCartesian) {
-  	  bool containsX = false;
-  	  bool containsY = false;
-  	  bool containsZ = false;
-  	  bool containsI = false;
-	  // investiage whether pointcloud_msg contains fields x,y,z,i
-  	  for (const auto& field : pointcloud_msg.fields) {
-		  if (field.name == "x") containsX = true;
-		  if (field.name == "y") containsY = true;
-		  if (field.name == "z") containsZ = true;
-		  if (field.name == "i") containsI = true;
-	  }
-  	isCartesian = containsX && containsY && containsZ && containsI;
+  	 isCartesian = hasPointcloudRequiredFields(pointcloud_msg, MinimalCartesianPointCloudFields);
   }
   if (isCartesian)
 	{
@@ -498,18 +498,7 @@ void sick_scansegment_xd::RosMsgpackPublisher::publishPointCloud2Msg(rosNodePtr 
 #else
   bool isPolar = (coordinate_notation == 1);
   if (!isPolar) {
-	  bool containsAzimuth = false;
-	  bool containsElevation = false;
-	  bool containsR = false;
-      bool containsI = false;
-	  // investiage whether pointcloud_msg contains fields azimuth,elevation,r,i
-  	  for (const auto& field : pointcloud_msg.fields) {
-		  if (field.name == "azimuth") containsAzimuth = true;
-		  if (field.name == "elevation") containsElevation = true;
-  	  	  if (field.name == "i") containsI = true;
-		  if (field.name == "range") containsR = true;
-	  }
-  	  isPolar = containsAzimuth && containsElevation && containsR && containsI;
+	 isPolar = hasPointcloudRequiredFields(pointcloud_msg, MinimalPolarPointCloudFields);
   }
 
   if (isPolar) // coordinateNotation=1: polar (pointcloud has fields azimuth,elevation,r,i) => notify polar pointcloud listener

--- a/include/sick_scansegment_xd/ros_msgpack_publisher.h
+++ b/include/sick_scansegment_xd/ros_msgpack_publisher.h
@@ -60,7 +60,7 @@
 #include "sick_scan/sick_ros_wrapper.h"
 #include "sick_scansegment_xd/config.h"
 #include "sick_scansegment_xd/msgpack_exporter.h"
-
+#include <unordered_set>
 namespace sick_scansegment_xd
 {
     /*
@@ -97,6 +97,15 @@ namespace sick_scansegment_xd
         size_t fieldoffset = 0;  // offset in bytes in structure PointXYZRAEI32f
     };
 
+    /** @brief Set of field names for Cartesian pointclouds, i.e. pointclouds with fields x, y, z */
+    const std::unordered_set<std::string> MinimalCartesianPointCloudFields = {
+        "x", "y", "z"
+    };
+
+    /** @brief Set of field names for Polar pointclouds, i.e. pointclouds with fields azimuth, elevation, range */
+    const std::unordered_set<std::string> MinimalPolarPointCloudFields = {
+        "azimuth", "elevation", "range"
+    };
 
     /** @brief Configuration of customized pointclouds */
     class CustomPointCloudConfiguration
@@ -382,6 +391,9 @@ namespace sick_scansegment_xd
 
         /** Prints (elevation,azimuth) values of the coverage table of collected lidar points */
         std::string printCoverageTable(const std::map<int, std::map<int, int>>& elevation_azimuth_histograms);
+
+        /** Checks if a PointCloud2Msg has all required fields */
+        bool hasPointcloudRequiredFields(const PointCloud2Msg& pointcloud_msg, const std::unordered_set<std::string>& required_fields) const;
 
         bool m_active; // activate publishing
         rosNodePtr m_node; // ros node handle


### PR DESCRIPTION
In current implementation the `coordinateNotation` value is checked. It is fine, unless you want to add more fields.

# How this PR was tested

I've run build example an run against multiscan136.