### PR TITLE
Supply ROS_VERSION environment variable

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,9 +15,9 @@
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
   <buildtool_depend condition="$ROS_VERSION != 1">ament_cmake</buildtool_depend>
 
+  <build_depend>ros_environment</build_depend>  <!-- Supplies ROS_VERSION environment variable -->
   <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
   <build_depend condition="$ROS_VERSION != 1">rosidl_default_generators</build_depend>
-  <build_depend>ros_environment</build_depend>  <!-- Supplies ROS_VERSION environment variable -->
 
   <depend condition="$ROS_VERSION == 1">dynamic_reconfigure</depend>
   <depend condition="$BUILD_WITH_LDMRS_SUPPORT == True">libsick_ldmrs</depend>


### PR DESCRIPTION
Fixes the buildfarm issues I think.

I've had to do this in multiple packages which depend on environment variables. 
https://build.ros2.org/job/Kbin_uN64__sick_scan_xd__ubuntu_noble_amd64__binary/141/console