### PR TITLE
add missing include for gcc15

### DIFF
--- a/include/sick_scansegment_xd/msgpack11/msgpack11.hpp
+++ b/include/sick_scansegment_xd/msgpack11/msgpack11.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>


### PR DESCRIPTION
Hi,

this is a simple fix for:
```cpp
In file included from /build/sick_scan_xd-release-release-humble-sick_scan_xd-3.9.0-1/driver/src/sick_scansegment_xd/msgpack11/msgpack11.cpp:1:
/build/sick_scan_xd-release-release-humble-sick_scan_xd-3.9.0-1/include/sick_scansegment_xd/msgpack11/msgpack11.hpp:60:25: error: 'uint8_t' was not declared in this scope
   60 |     typedef std::vector<uint8_t> binary;
      |                         ^~~~~~~
```