### PR TITLE
Fix `fork()` stub compilation for MSVC

### DIFF
--- a/roswrap/src/rossimu/kinetic/src/rossimu.cpp
+++ b/roswrap/src/rossimu/kinetic/src/rossimu.cpp
@@ -489,12 +489,14 @@ int rossimu_settings(ros::NodeHandle& nhPriv)
 	return(0);
 }
 
+#ifdef _MSC_VER
+
 int fork()
 {
 	return(0);
 }
 
-#ifdef _MSC_VER
+
 void sleep(int secs)
 {
 	Sleep(secs * 1000);


### PR DESCRIPTION
* Fix `fork()` stub compilation for MSVC in ROS simulation 
* See also issue #571 for more details