### PR TITLE
feat(lidoutputstate): poll output state and detect connection loss

### DIFF
--- a/driver/src/sick_scan_common_nw.cpp
+++ b/driver/src/sick_scan_common_nw.cpp
@@ -76,6 +76,7 @@
 #include "sick_scan/tcp/errorhandler.hpp"
 #include "sick_scan/tcp/toolbox.hpp"
 #include "sick_scan/tcp/Mutex.hpp"
+#include "sick_scan/sick_scan_logging.h"
 #include <assert.h>
 
 SickScanCommonNw::SickScanCommonNw()
@@ -174,6 +175,20 @@ bool SickScanCommonNw::isConnected()
 }
 
 
+//
+// Called from the tcp read thread when the peer closed the connection or the socket read
+// failed. Only moves CONNECTED -> CONSTRUCTED; the socket itself is closed by Tcp.
+//
+void SickScanCommonNw::setDisconnected()
+{
+  State expected = CONNECTED;
+  if (m_state.compare_exchange_strong(expected, CONSTRUCTED))
+  {
+    ROS_ERROR_STREAM("SickScanCommonNw::setDisconnected(): tcp connection to " << m_ipAddress << ":" << m_portNumber << " lost.");
+  }
+}
+
+
 /**
  * Open TCP-connection to endpoint (usually IP-address and port)
  *
@@ -238,8 +253,10 @@ void SickScanCommonNw::readCallbackFunction(UINT8 *buffer, UINT32 &numOfBytes)
   if (remainingSpace < numOfBytes)
   {
     bytesToBeTransferred = remainingSpace;
-    // printWarning("SickScanCommonNw::readCallbackFunction(): Input buffer space is to small, transferring only " +
-    //              ::toString(bytesToBeTransferred) + " of " + ::toString(numOfBytes) + " bytes.");
+    // Dropping bytes here corrupts the sopas frame stream: telegrams are silently lost or
+    // mis-parsed. This must never pass unnoticed, so the warning stays enabled.
+    printWarning("SickScanCommonNw::readCallbackFunction(): Input buffer space is to small, transferring only " +
+                 ::toString(bytesToBeTransferred) + " of " + ::toString(numOfBytes) + " bytes.");
   }
   else
   {

--- a/driver/src/sick_scan_common_tcp.cpp
+++ b/driver/src/sick_scan_common_tcp.cpp
@@ -252,7 +252,24 @@ namespace sick_scan_xd
 
   void SickScanCommonTcp::disconnectFunction()
   {
+    // Invoked by the tcp read thread when the peer closed the connection. Mark the
+    // connection lost so that isConnected() reports it and the driver can reconnect.
+    m_nw.setDisconnected();
+  }
 
+  int SickScanCommonTcp::sendSopasRequestNoReply(const std::string& sopasCmd, bool cola_binary)
+  {
+    // Same lock sendSopasAndCheckAnswer() takes: this is called from the LIDoutputstate worker
+    // thread while ros service callbacks may be sending on the very same socket.
+    std::lock_guard<std::mutex> send_lock_guard(sopasSendMutex);
+    std::string sopasRequest = std::string("\x02") + sopasCmd + "\x03";
+    if (cola_binary)
+    {
+      std::vector<unsigned char> reqBinary;
+      convertAscii2BinaryCmd(sopasRequest.c_str(), &reqBinary);
+      return sendSOPASCommand((const char *) reqBinary.data(), 0, (int) reqBinary.size(), false);
+    }
+    return sendSOPASCommand(sopasRequest.c_str(), 0, (int) sopasRequest.size(), false);
   }
 
   void SickScanCommonTcp::disconnectFunctionS(void *obj)

--- a/driver/src/sick_scan_messages.cpp
+++ b/driver/src/sick_scan_messages.cpp
@@ -163,11 +163,9 @@ bool sick_scan_xd::SickScanMessages::parseLIDoutputstateMsg(const rosTime& timeS
                 ROS_ERROR_STREAM("## ERROR SickScanMessages::parseLIDoutputstateMsg(): error parsing version_number and system_counter (" << __FILE__ << ":" << __LINE__ << ")");
                 return false;
             }
-            if(output_state == 0 || output_state == 1) // 0: not active, 1: active, 2: not used
-            {
-                output_msg.output_state.push_back(output_state);
-                output_msg.output_count.push_back(output_count);
-            }
+            // Push every output, including those reported as "not used" (state 2).
+            output_msg.output_state.push_back(output_state);
+            output_msg.output_count.push_back(output_count);
         }
         // Read timestamp state
         if( !readBinaryBuffer(receiveBuffer, receiveLength, output_msg.time_state))
@@ -232,7 +230,9 @@ bool sick_scan_xd::SickScanMessages::parseLIDoutputstateMsg(const rosTime& timeS
             uint32_t output_state = 2, output_count = 0; // output_state 2: not used
             msg_ptr = readNextAsciiHexValue(msg_ptr, &output_state);
             msg_ptr = readNextAsciiHexValue(msg_ptr, &output_count);
-            if (msg_ptr && (output_state == 0 || output_state == 1)) // 0: not active, 1: active, 2: not used
+            // Keep unused outputs (state 2) in the array so the index stays aligned with the
+            // physical output number - see the note in the Cola-B branch above.
+            if (msg_ptr)
             {
                 output_msg.output_state.push_back((uint8_t)(output_state & 0xFF));
                 output_msg.output_count.push_back(output_count);
@@ -240,6 +240,13 @@ bool sick_scan_xd::SickScanMessages::parseLIDoutputstateMsg(const rosTime& timeS
         }
         for(int state_cnt = 0; state_cnt < 8; state_cnt++) // Read state and count of Ext.Out1 to Ext.Out8 (not supported?)
         {
+        }
+        if (output_msg.output_state.empty())
+        {
+            // Not a single output could be parsed, i.e. this telegram does not carry an output state (a truncated telegram)
+            ROS_WARN_STREAM("## ERROR SickScanMessages::parseLIDoutputstateMsg(): no output state in "
+                << receiveLength << " byte telegram, ignored (" << __FILE__ << ":" << __LINE__ << ")");
+            return false;
         }
         // Read optional date and time
         uint32_t time_state = 0, year = 0, month = 0, day = 0, hour = 0, minute = 0, second = 0, microsecond = 0;

--- a/driver/src/sick_scansegment_xd/config.cpp
+++ b/driver/src/sick_scansegment_xd/config.cpp
@@ -179,6 +179,8 @@ sick_scansegment_xd::Config::Config()
     user_level = 3;                          // Default user level for client authorization (3 -> "authorized client", 4 -> "service")
     user_level_password = "F4724744";        // Default password for client authorization 
     listen_only_mode = false;                // True: Skip initialization mode for segment base lidar and jump directly to listing of UDP data
+    activate_lidoutputstate = false;         // True: activate LIDoutputstate telegrams and publish topic "lidoutputstate", default: false
+    disable_udp_scandata = false;            // True: skip udp scan data reception entirely (no udp timeout/reconnect handling), default: false
 
     // MSR100 default filter settings
     host_read_filtersettings = true;                            // Read multiScan136 settings for FREchoFilter, LFPangleRangeFilter and LFPlayerFilter at startup, default: true
@@ -248,6 +250,8 @@ void sick_scansegment_xd::Config::PrintHelp(void)
     ROS_INFO_STREAM("-imu_topic=<name> : ROS topic of IMU messages, default: " << imu_topic);
     ROS_INFO_STREAM("-imu_udp_port=<port>: udp port for multiScan imu data, default: " << imu_udp_port);
     ROS_INFO_STREAM("-imu_latency_microsec=<micro_sec>: imu latency in microseconds, default: " << imu_latency_microsec);
+    ROS_INFO_STREAM("-activate_lidoutputstate=0|1 : activate LIDoutputstate telegrams and publish topic \"lidoutputstate\", default: " << activate_lidoutputstate);
+    ROS_INFO_STREAM("-disable_udp_scandata=0|1 : skip udp scan data reception entirely, no udp timeout/reconnect handling, default: " << disable_udp_scandata);
 }
 
 /*
@@ -299,6 +303,8 @@ bool sick_scansegment_xd::Config::Init(rosNodePtr _node)
     ROS_DECL_GET_PARAMETER(node, "user_level", user_level);
     ROS_DECL_GET_PARAMETER(node, "user_level_password", user_level_password);
     ROS_DECL_GET_PARAMETER(node, "listen_only_mode", listen_only_mode);
+    ROS_DECL_GET_PARAMETER(node, "activate_lidoutputstate", activate_lidoutputstate);
+    ROS_DECL_GET_PARAMETER(node, "disable_udp_scandata", disable_udp_scandata);
     ROS_DECL_GET_PARAMETER(node, "layer_lookup_table_id", layer_lookup_table_id);
     // MSR100 filter settings
     ROS_DECL_GET_PARAMETER(node, "host_read_filtersettings", host_read_filtersettings);
@@ -448,6 +454,8 @@ bool sick_scansegment_xd::Config::Init(int argc, char** argv)
     setOptionalArgument(cli_parameter_map, "user_level", user_level);
     setOptionalArgument(cli_parameter_map, "user_level_password", user_level_password);
     setOptionalArgument(cli_parameter_map, "listen_only_mode", listen_only_mode);
+    setOptionalArgument(cli_parameter_map, "activate_lidoutputstate", activate_lidoutputstate);
+    setOptionalArgument(cli_parameter_map, "disable_udp_scandata", disable_udp_scandata);
     setOptionalArgument(cli_parameter_map, "host_read_filtersettings", host_read_filtersettings);
     setOptionalArgument(cli_parameter_map, "host_FREchoFilter", host_FREchoFilter);
     setOptionalArgument(cli_parameter_map, "host_set_FREchoFilter", host_set_FREchoFilter);
@@ -501,6 +509,8 @@ void sick_scansegment_xd::Config::PrintConfig(void)
     ROS_INFO_STREAM("udp_sender:                       " << udp_sender);
     ROS_INFO_STREAM("udp_port:                         " << udp_port);
     ROS_INFO_STREAM("listen_only_mode:                 " << (listen_only_mode ? "true" : "false"));
+    ROS_INFO_STREAM("activate_lidoutputstate:          " << (activate_lidoutputstate ? "true" : "false"));
+    ROS_INFO_STREAM("disable_udp_scandata:             " << (disable_udp_scandata ? "true" : "false"));
     ROS_INFO_STREAM("check_udp_receiver_ip:            " << check_udp_receiver_ip);
     ROS_INFO_STREAM("check_udp_receiver_port:          " << check_udp_receiver_port);
     ROS_INFO_STREAM("all_segments_min_deg:             " << all_segments_min_deg);

--- a/driver/src/sick_scansegment_xd/config.cpp
+++ b/driver/src/sick_scansegment_xd/config.cpp
@@ -180,6 +180,7 @@ sick_scansegment_xd::Config::Config()
     user_level_password = "F4724744";        // Default password for client authorization 
     listen_only_mode = false;                // True: Skip initialization mode for segment base lidar and jump directly to listing of UDP data
     activate_lidoutputstate = false;         // True: activate LIDoutputstate telegrams and publish topic "lidoutputstate", default: false
+    lidoutputstate_period_ms = 0;            // Interval in ms at which the output state is re-read, refreshing topic "lidoutputstate". 0 (default): no cyclic polling; the state is still read once per connection
     disable_udp_scandata = false;            // True: skip udp scan data reception entirely (no udp timeout/reconnect handling), default: false
 
     // MSR100 default filter settings
@@ -251,6 +252,7 @@ void sick_scansegment_xd::Config::PrintHelp(void)
     ROS_INFO_STREAM("-imu_udp_port=<port>: udp port for multiScan imu data, default: " << imu_udp_port);
     ROS_INFO_STREAM("-imu_latency_microsec=<micro_sec>: imu latency in microseconds, default: " << imu_latency_microsec);
     ROS_INFO_STREAM("-activate_lidoutputstate=0|1 : activate LIDoutputstate telegrams and publish topic \"lidoutputstate\", default: " << activate_lidoutputstate);
+    ROS_INFO_STREAM("-lidoutputstate_period_ms=<ms> : interval at which the output state is re-read, refreshing topic \"lidoutputstate\", 0 for no cyclic polling (state still read once per connection), default: " << lidoutputstate_period_ms);
     ROS_INFO_STREAM("-disable_udp_scandata=0|1 : skip udp scan data reception entirely, no udp timeout/reconnect handling, default: " << disable_udp_scandata);
 }
 
@@ -304,6 +306,7 @@ bool sick_scansegment_xd::Config::Init(rosNodePtr _node)
     ROS_DECL_GET_PARAMETER(node, "user_level_password", user_level_password);
     ROS_DECL_GET_PARAMETER(node, "listen_only_mode", listen_only_mode);
     ROS_DECL_GET_PARAMETER(node, "activate_lidoutputstate", activate_lidoutputstate);
+    ROS_DECL_GET_PARAMETER(node, "lidoutputstate_period_ms", lidoutputstate_period_ms);
     ROS_DECL_GET_PARAMETER(node, "disable_udp_scandata", disable_udp_scandata);
     ROS_DECL_GET_PARAMETER(node, "layer_lookup_table_id", layer_lookup_table_id);
     // MSR100 filter settings
@@ -455,6 +458,7 @@ bool sick_scansegment_xd::Config::Init(int argc, char** argv)
     setOptionalArgument(cli_parameter_map, "user_level_password", user_level_password);
     setOptionalArgument(cli_parameter_map, "listen_only_mode", listen_only_mode);
     setOptionalArgument(cli_parameter_map, "activate_lidoutputstate", activate_lidoutputstate);
+    setOptionalArgument(cli_parameter_map, "lidoutputstate_period_ms", lidoutputstate_period_ms);
     setOptionalArgument(cli_parameter_map, "disable_udp_scandata", disable_udp_scandata);
     setOptionalArgument(cli_parameter_map, "host_read_filtersettings", host_read_filtersettings);
     setOptionalArgument(cli_parameter_map, "host_FREchoFilter", host_FREchoFilter);
@@ -510,6 +514,7 @@ void sick_scansegment_xd::Config::PrintConfig(void)
     ROS_INFO_STREAM("udp_port:                         " << udp_port);
     ROS_INFO_STREAM("listen_only_mode:                 " << (listen_only_mode ? "true" : "false"));
     ROS_INFO_STREAM("activate_lidoutputstate:          " << (activate_lidoutputstate ? "true" : "false"));
+    ROS_INFO_STREAM("lidoutputstate_period_ms:         " << lidoutputstate_period_ms);
     ROS_INFO_STREAM("disable_udp_scandata:             " << (disable_udp_scandata ? "true" : "false"));
     ROS_INFO_STREAM("check_udp_receiver_ip:            " << check_udp_receiver_ip);
     ROS_INFO_STREAM("check_udp_receiver_port:          " << check_udp_receiver_port);

--- a/driver/src/sick_scansegment_xd/scansegment_threads.cpp
+++ b/driver/src/sick_scansegment_xd/scansegment_threads.cpp
@@ -64,9 +64,47 @@
 #include "sick_scan/sick_scan_services.h"
 #include "sick_scan/sick_scan_messages.h"
 #include "sick_scan/sick_generic_callback.h"
+#include <algorithm>
 #include <atomic>
+#include <chrono>
+#include <string>
 
 #define DELETE_PTR(p) do{if(p){delete(p);(p)=0;}}while(false)
+
+namespace
+{
+    /*
+     * Returns the 3 character sopas command id of a raw datagram, e.g. "sSN" for an event telegram,
+     * "sRA" for a read reply, "sEA" for an event-subscription acknowledge or "sFA" for an error reply.
+     * Returns an empty string if the datagram is too short to carry one.
+     */
+    std::string sopasCommandId(const std::vector<unsigned char>& datagram)
+    {
+        const uint32_t cola_b_start = 0x02020202;
+        if (datagram.size() > 12 && memcmp(datagram.data(), &cola_b_start, sizeof(cola_b_start)) == 0)
+        {
+            return std::string((const char*)datagram.data() + 8, 3); // 0x02020202 + { 4 byte payload length }
+        }
+        if (datagram.size() > 5)
+        {
+            return std::string((const char*)datagram.data() + 1, 3); // 0x02
+        }
+        return std::string();
+    }
+
+    /*
+     * Publishes a LIDoutputstate message with an empty output_state array, i.e. "the output states
+     * are not known". Sent while the sopas connection is down, so that a subscriber is told at once
+     * rather than having to wait for its own timeout to expire.
+     */
+    void publishLIDoutputstateUnknown(rosPublisher<sick_scan_msg::LIDoutputstateMsg>& publisher, const std::string& frame_id)
+    {
+        sick_scan_msg::LIDoutputstateMsg msg;
+        msg.header.stamp = rosTimeNow();
+        msg.header.frame_id = frame_id;
+        rosPublish(publisher, msg);
+    }
+}
 
 sick_scan_xd::SickScanServices* s_sopas_service = 0;
 sick_scan_xd::SickScanServices* sick_scansegment_xd::sopasService() { return s_sopas_service; }
@@ -207,6 +245,22 @@ bool sick_scansegment_xd::MsgPackThreads::runThreadCb(void)
         sick_scansegment_xd::MkDir(m_config.logfolder);  // create log folder (if configured)
     }
 
+    // Publisher for LIDoutputstate messages (safety I/O field monitoring output state).
+    // Latched (transient local): the device sends LIDoutputstate telegrams on change only (or on request), so a
+    // subscriber that starts later than the driver would otherwise never learn the current state.
+    rosPublisher<sick_scan_msg::LIDoutputstateMsg> lidoutputstate_publisher;
+    if (m_config.activate_lidoutputstate)
+    {
+#if __ROS_VERSION == 2
+        lidoutputstate_publisher = rosAdvertise<sick_scan_msg::LIDoutputstateMsg>(m_config.node, "lidoutputstate", 1, rclcpp::SystemDefaultsQoS(), true);
+#else
+        lidoutputstate_publisher = rosAdvertise<sick_scan_msg::LIDoutputstateMsg>(m_config.node, "lidoutputstate", 1, 10, true);
+#endif
+        sick_scan_xd::setLIDoutputstateTopic("lidoutputstate");
+        // Nothing is known about the lidar yet - say so until it has actually been read.
+        publishLIDoutputstateUnknown(lidoutputstate_publisher, m_config.publish_frame_id);
+    }
+
     // (Re-)initialize and run loop
     while(m_run_scansegment_thread && rosOk())
     {
@@ -286,15 +340,8 @@ bool sick_scansegment_xd::MsgPackThreads::runThreadCb(void)
         sick_scan_xd::SickGenericParser parser = sick_scan_xd::SickGenericParser(scannerName);
         sick_scan_xd::ScannerBasicParam basic_param;
         basic_param.setScannerName(scannerName);
-        // Optional publisher for LIDoutputstate messages (safety I/O field monitoring output state)
-        rosPublisher<sick_scan_msg::LIDoutputstateMsg> lidoutputstate_publisher;
         std::atomic<bool> run_lidoutputstate_thread(false);
         std::thread lidoutputstate_thread;
-        if (m_config.activate_lidoutputstate)
-        {
-            lidoutputstate_publisher = rosAdvertise<sick_scan_msg::LIDoutputstateMsg>(m_config.node, "lidoutputstate", 100);
-            sick_scan_xd::setLIDoutputstateTopic("lidoutputstate");
-        }
         bool multiscan_write_filtersettings = m_config.host_set_FREchoFilter || m_config.host_set_LFPangleRangeFilter || m_config.host_set_LFPlayerFilter;
         if (m_config.start_sopas_service || m_config.send_sopas_start_stop_cmd || m_config.host_read_filtersettings || multiscan_write_filtersettings)
         {
@@ -385,6 +432,7 @@ bool sick_scansegment_xd::MsgPackThreads::runThreadCb(void)
         }
 
         // Activate LIDoutputstate telegrams (safety I/O field monitoring output state), if configured
+        bool lidoutputstate_activation_failed = false;
         if (m_config.activate_lidoutputstate && sopas_tcp && sopas_service && sopas_tcp->isConnected())
         {
             sick_scan_srv::LIDoutputstateSrv::Request lidoutputstate_request;
@@ -392,18 +440,50 @@ bool sick_scansegment_xd::MsgPackThreads::runThreadCb(void)
             lidoutputstate_request.active = true;
             if (!sopas_service->serviceCbLIDoutputstate(lidoutputstate_request, lidoutputstate_response) || !lidoutputstate_response.success)
             {
-                ROS_ERROR_STREAM("## ERROR sick_scansegment_xd: failed to activate LIDoutputstate telegrams.");
+                ROS_ERROR_STREAM("## ERROR sick_scansegment_xd: failed to activate LIDoutputstate telegrams, reconnecting.");
+                lidoutputstate_activation_failed = true;
+                publishLIDoutputstateUnknown(lidoutputstate_publisher, m_config.publish_frame_id);
             }
-            // Dedicated worker thread blocking on recvQueue instead of polling: wakes immediately when a LIDoutputstate telegram arrives
+        }
+        if (m_config.activate_lidoutputstate && !lidoutputstate_activation_failed && sopas_tcp && sopas_service && sopas_tcp->isConnected())
+        {
+            // Dedicated worker thread: the only consumer of LIDoutputstate datagrams, so a non-blocking
+            // tryPop is safe and no other thread can steal a datagram between the wait and the pop.
             run_lidoutputstate_thread = true;
             lidoutputstate_thread = std::thread([this, sopas_tcp, &lidoutputstate_publisher, &run_lidoutputstate_thread]()
             {
                 static const std::vector<std::string> lidoutputstate_keywords = { "LIDoutputstate" };
+
+                // A period of 0 turns polling off and leaves the original behaviour: the topic is
+                // then only written when an output actually changes, and stays silent otherwise.
+                const bool poll_enabled = m_config.lidoutputstate_period_ms > 0;
+                const std::chrono::milliseconds poll_period(poll_enabled ? m_config.lidoutputstate_period_ms : 0);
+
+                // Read the state once per connection
+                bool initial_read_done = false;
+                auto next_poll = std::chrono::steady_clock::now();
+
                 while (run_lidoutputstate_thread && m_run_scansegment_thread && rosOk())
                 {
-                    if (sopas_tcp->recvQueue.waitForIncomingObject(200, lidoutputstate_keywords))
+                    sopas_tcp->recvQueue.waitForIncomingObject(20, lidoutputstate_keywords);
+
+                    // Drain whatever arrived: event telegrams (sSN) and replies to our own poll (sRA).
+                    sick_scan_xd::DatagramWithTimeStamp lidoutputstate_datagram(rosTimeNow(), std::vector<unsigned char>());
+                    while (sopas_tcp->recvQueue.tryPop(lidoutputstate_keywords, lidoutputstate_datagram))
                     {
-                        sick_scan_xd::DatagramWithTimeStamp lidoutputstate_datagram = sopas_tcp->recvQueue.pop(lidoutputstate_keywords);
+                        // The keyword filter matches any command id carrying "LIDoutputstate", including
+                        // the "sEA" activation acknowledge and "sFA" error replies. Only the event
+                        // telegram (sSN) and the reply to our own poll (sRA) carry an output state.
+                        const std::string command_id = sopasCommandId(lidoutputstate_datagram.data());
+                        if (command_id != "sSN" && command_id != "sRA")
+                        {
+                            if (command_id == "sFA")
+                            {
+                                // The device rejected a request - most likely it does not support reading LIDoutputstate as a variable
+                                ROS_WARN_STREAM("## ERROR sick_scansegment_xd: device answered a LIDoutputstate request with an error (sFA)");
+                            }
+                            continue;
+                        }
                         sick_scan_msg::LIDoutputstateMsg lidoutputstate_msg;
                         if (sick_scan_xd::SickScanMessages::parseLIDoutputstateMsg(lidoutputstate_datagram.timeStamp, lidoutputstate_datagram.data().data(),
                             (int)lidoutputstate_datagram.data().size(), m_config.sopas_cola_binary, m_config.publish_frame_id, lidoutputstate_msg))
@@ -416,7 +496,21 @@ bool sick_scansegment_xd::MsgPackThreads::runThreadCb(void)
                             ROS_WARN_STREAM("## ERROR sick_scansegment_xd: parseLIDoutputstateMsg failed, " << lidoutputstate_datagram.data().size() << " byte telegram ignored");
                         }
                     }
+
+                    const auto now = std::chrono::steady_clock::now();
+                    const bool read_due = !initial_read_done || (poll_enabled && now >= next_poll);
+                    if (read_due && sopas_tcp->isConnected())
+                    {
+                        initial_read_done = true;
+                        next_poll = now + poll_period;
+                        if (sopas_tcp->sendSopasRequestNoReply("sRN LIDoutputstate", m_config.sopas_cola_binary) != 0)
+                        {
+                            ROS_WARN_STREAM("## ERROR sick_scansegment_xd: failed to send \"sRN LIDoutputstate\" request");
+                        }
+                    }
                 }
+                // Say "no data" at once on the way out.
+                publishLIDoutputstateUnknown(lidoutputstate_publisher, m_config.publish_frame_id);
             });
         }
 
@@ -437,12 +531,14 @@ bool sick_scansegment_xd::MsgPackThreads::runThreadCb(void)
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }    
         // Monitor udp packets with timeout for udp messages in milliseconds, default: 10*1000
-        while(m_run_scansegment_thread && rosOk())
+        while(m_run_scansegment_thread && rosOk() && !lidoutputstate_activation_failed)
         {
             if (!sopas_tcp->isConnected())
             {
               // Suppress the warning in listen-only mode; otherwise, display it.
-              if (!sopas_tcp->getListenOnlyMode())
+              // With activate_lidoutputstate the sopas connection carries the output states, so a
+              // lost connection always has to be acted on - there is no other data path left.
+              if (!sopas_tcp->getListenOnlyMode() || m_config.activate_lidoutputstate)
               {
                 ROS_ERROR_STREAM("## ERROR sick_scansegment_xd: sopas tcp connection lost, stop and reconnect...");
                 break;

--- a/driver/src/sick_scansegment_xd/scansegment_threads.cpp
+++ b/driver/src/sick_scansegment_xd/scansegment_threads.cpp
@@ -62,6 +62,9 @@
 #include "sick_scansegment_xd/scansegment_parser_output.h"
 #include "sick_scansegment_xd/udp_receiver.h"
 #include "sick_scan/sick_scan_services.h"
+#include "sick_scan/sick_scan_messages.h"
+#include "sick_scan/sick_generic_callback.h"
+#include <atomic>
 
 #define DELETE_PTR(p) do{if(p){delete(p);(p)=0;}}while(false)
 
@@ -283,6 +286,15 @@ bool sick_scansegment_xd::MsgPackThreads::runThreadCb(void)
         sick_scan_xd::SickGenericParser parser = sick_scan_xd::SickGenericParser(scannerName);
         sick_scan_xd::ScannerBasicParam basic_param;
         basic_param.setScannerName(scannerName);
+        // Optional publisher for LIDoutputstate messages (safety I/O field monitoring output state)
+        rosPublisher<sick_scan_msg::LIDoutputstateMsg> lidoutputstate_publisher;
+        std::atomic<bool> run_lidoutputstate_thread(false);
+        std::thread lidoutputstate_thread;
+        if (m_config.activate_lidoutputstate)
+        {
+            lidoutputstate_publisher = rosAdvertise<sick_scan_msg::LIDoutputstateMsg>(m_config.node, "lidoutputstate", 100);
+            sick_scan_xd::setLIDoutputstateTopic("lidoutputstate");
+        }
         bool multiscan_write_filtersettings = m_config.host_set_FREchoFilter || m_config.host_set_LFPangleRangeFilter || m_config.host_set_LFPlayerFilter;
         if (m_config.start_sopas_service || m_config.send_sopas_start_stop_cmd || m_config.host_read_filtersettings || multiscan_write_filtersettings)
         {
@@ -372,6 +384,42 @@ bool sick_scansegment_xd::MsgPackThreads::runThreadCb(void)
             }
         }
 
+        // Activate LIDoutputstate telegrams (safety I/O field monitoring output state), if configured
+        if (m_config.activate_lidoutputstate && sopas_tcp && sopas_service && sopas_tcp->isConnected())
+        {
+            sick_scan_srv::LIDoutputstateSrv::Request lidoutputstate_request;
+            sick_scan_srv::LIDoutputstateSrv::Response lidoutputstate_response;
+            lidoutputstate_request.active = true;
+            if (!sopas_service->serviceCbLIDoutputstate(lidoutputstate_request, lidoutputstate_response) || !lidoutputstate_response.success)
+            {
+                ROS_ERROR_STREAM("## ERROR sick_scansegment_xd: failed to activate LIDoutputstate telegrams.");
+            }
+            // Dedicated worker thread blocking on recvQueue instead of polling: wakes immediately when a LIDoutputstate telegram arrives
+            run_lidoutputstate_thread = true;
+            lidoutputstate_thread = std::thread([this, sopas_tcp, &lidoutputstate_publisher, &run_lidoutputstate_thread]()
+            {
+                static const std::vector<std::string> lidoutputstate_keywords = { "LIDoutputstate" };
+                while (run_lidoutputstate_thread && m_run_scansegment_thread && rosOk())
+                {
+                    if (sopas_tcp->recvQueue.waitForIncomingObject(200, lidoutputstate_keywords))
+                    {
+                        sick_scan_xd::DatagramWithTimeStamp lidoutputstate_datagram = sopas_tcp->recvQueue.pop(lidoutputstate_keywords);
+                        sick_scan_msg::LIDoutputstateMsg lidoutputstate_msg;
+                        if (sick_scan_xd::SickScanMessages::parseLIDoutputstateMsg(lidoutputstate_datagram.timeStamp, lidoutputstate_datagram.data().data(),
+                            (int)lidoutputstate_datagram.data().size(), m_config.sopas_cola_binary, m_config.publish_frame_id, lidoutputstate_msg))
+                        {
+                            sick_scan_xd::notifyLIDoutputstateListener(m_config.node, &lidoutputstate_msg);
+                            rosPublish(lidoutputstate_publisher, lidoutputstate_msg);
+                        }
+                        else
+                        {
+                            ROS_WARN_STREAM("## ERROR sick_scansegment_xd: parseLIDoutputstateMsg failed, " << lidoutputstate_datagram.data().size() << " byte telegram ignored");
+                        }
+                    }
+                }
+            });
+        }
+
         // Activate message parsing and publishing AFTER initialization completed
         msgpack_converter.SetActive(true);
         ros_msgpack_publisher->SetActive(true);
@@ -380,8 +428,9 @@ bool sick_scansegment_xd::MsgPackThreads::runThreadCb(void)
         setDiagnosticStatus(SICK_DIAGNOSTIC_STATUS::OK, "");
         s_sopas_service = sopas_service;
         // Wait for first udp message with initial timeout after start in milliseconds, default: 60*1000
+        // Skipped entirely if disable_udp_scandata is set, i.e. the lidar is not expected to send scan data over udp
         fifo_timestamp fifo_timestamp_start = fifo_clock::now();
-        while(m_run_scansegment_thread && rosOk() && sopas_tcp->isConnected() 
+        while(!m_config.disable_udp_scandata && m_run_scansegment_thread && rosOk() && sopas_tcp->isConnected() 
             && udp_receiver->Fifo()->TotalMessagesPushed() <= 1 
             && udp_receiver->Fifo()->Seconds(fifo_timestamp_start, fifo_clock::now()) <= 1.0e-3 * m_config.udp_timeout_ms_initial)
         {
@@ -399,7 +448,7 @@ bool sick_scansegment_xd::MsgPackThreads::runThreadCb(void)
                 break;
               }
             }
-            if (udp_receiver->Fifo()->TotalMessagesPushed() <= 1 || udp_receiver->Fifo()->SecondsSinceLastPush() > 1.0e-3 * m_config.udp_timeout_ms)
+            if (!m_config.disable_udp_scandata && (udp_receiver->Fifo()->TotalMessagesPushed() <= 1 || udp_receiver->Fifo()->SecondsSinceLastPush() > 1.0e-3 * m_config.udp_timeout_ms))
             {
                 ROS_ERROR_STREAM("## ERROR sick_scansegment_xd: " << (udp_receiver->Fifo()->TotalMessagesPushed()) << " udp messages received");
                 if (udp_receiver->Fifo()->TotalMessagesPushed() > 0)
@@ -419,6 +468,11 @@ bool sick_scansegment_xd::MsgPackThreads::runThreadCb(void)
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
         s_sopas_service = 0;
+
+        // Stop the LIDoutputstate worker thread before tearing down the sopas tcp connection
+        run_lidoutputstate_thread = false;
+        if (lidoutputstate_thread.joinable())
+            lidoutputstate_thread.join();
 
         // Close msgpack receiver, converter and exporter
         setDiagnosticStatus(SICK_DIAGNOSTIC_STATUS::EXIT, "sick_scan_xd exit");
@@ -440,6 +494,13 @@ bool sick_scansegment_xd::MsgPackThreads::runThreadCb(void)
             std::cout << "sick_scansegment_xd exit: sending stop commands..." << std::endl;
             sopas_service->sendAuthorization();//(m_config.client_authorization_pw);
             sopas_service->sendMultiScanStopCmd(m_config.imu_enable);
+            if (m_config.activate_lidoutputstate)
+            {
+                sick_scan_srv::LIDoutputstateSrv::Request lidoutputstate_request;
+                sick_scan_srv::LIDoutputstateSrv::Response lidoutputstate_response;
+                lidoutputstate_request.active = false;
+                sopas_service->serviceCbLIDoutputstate(lidoutputstate_request, lidoutputstate_response);
+            }
             std::cout << "sick_scansegment_xd exit: stop commands sent." << std::endl;
         }
         // Stop SOPAS services

--- a/driver/src/tcp/tcp.cpp
+++ b/driver/src/tcp/tcp.cpp
@@ -15,6 +15,8 @@
 #else
 #include <sys/socket.h> // for socket(), bind(), and connect()
 #include <arpa/inet.h>  // for sockaddr_in and inet_ntoa()
+#include <netinet/in.h>  // for IPPROTO_TCP
+#include <netinet/tcp.h> // for TCP_KEEPIDLE / TCP_KEEPINTVL / TCP_KEEPCNT
 #endif
 #include <string.h>     // for memset()
 #include <netdb.h>      // for hostent
@@ -179,6 +181,27 @@ bool Tcp::open(std::string ipAddress, UINT16 port, bool enableVerboseDebugOutput
 		return false;
 	}
 
+	// Enable TCP keepalive so that a lost link (cable pull, device power loss) is detected
+	// within seconds instead of the OS default of ~2 hours. Without this, a silent peer
+	// leaves the socket readable-but-idle forever and the driver never notices.
+	// Best effort: a platform that does not support the per-socket tuning still gets the
+	// system default keepalive rather than none at all.
+	{
+		int keepalive_enable = 1;
+		if (setsockopt(m_connectionSocket, SOL_SOCKET, SO_KEEPALIVE, (const char*)&keepalive_enable, sizeof(keepalive_enable)) < 0)
+		{
+			ROS_WARN_STREAM("Tcp::open: setsockopt(SO_KEEPALIVE) failed, connection loss may go undetected.");
+		}
+#if defined TCP_KEEPIDLE && defined TCP_KEEPINTVL && defined TCP_KEEPCNT
+		int keepalive_idle_sec = 2;   // start probing after 2 s of idle
+		int keepalive_intvl_sec = 1;  // probe every 1 s
+		int keepalive_probes = 3;     // give up after 3 failed probes (~5 s total)
+		setsockopt(m_connectionSocket, IPPROTO_TCP, TCP_KEEPIDLE, (const char*)&keepalive_idle_sec, sizeof(keepalive_idle_sec));
+		setsockopt(m_connectionSocket, IPPROTO_TCP, TCP_KEEPINTVL, (const char*)&keepalive_intvl_sec, sizeof(keepalive_intvl_sec));
+		setsockopt(m_connectionSocket, IPPROTO_TCP, TCP_KEEPCNT, (const char*)&keepalive_probes, sizeof(keepalive_probes));
+#endif
+	}
+
 	// Socket ist da. Nun die Verbindung oeffnen.
 	ROS_INFO_STREAM("sick_scan_xd: Tcp::open: connecting to " << ipAddress << ":"  << port << " ...");
 	printInfoMessage("Tcp::open: Connecting. Target address is " + ipAddress + ":" + toString(port) + ".", m_beVerbose);
@@ -326,6 +349,14 @@ INT32 Tcp::readInputData()
   		ROS_ERROR("Tcp::readInputData: Failed to read data from socket, aborting!");
 		else
   		ROS_INFO("Tcp::readInputData: Failed to read data from socket, aborting!");
+
+		// A read error is a lost connection just as much as a clean close is - notify so the
+		// driver can detect it. Previously only the recvMsgSize == 0 case below notified.
+		if (m_disconnectFunction != NULL)
+		{
+			m_disconnectFunction(m_disconnectFunctionObjPtr);
+		}
+
 		ScopedLock lock(&m_socketMutex);
 		closeSocket(); // otherwise the driver can terminate with broken pipe in next call to Tcp::write()
 	}

--- a/include/sick_scan/sick_scan_common.h
+++ b/include/sick_scan/sick_scan_common.h
@@ -553,6 +553,9 @@ namespace sick_scan_xd
 
     int readTimeOutInMs;
 
+  protected:
+    // Locked by every sopas send, including sendSopasRequestNoReply() in the derived tcp class,
+    // which is called from a worker thread while service callbacks may send on the same socket.
     std::mutex sopasSendMutex; // mutex to lock sendSopasAndCheckAnswer
 
   private:

--- a/include/sick_scan/sick_scan_common_nw.h
+++ b/include/sick_scan/sick_scan_common_nw.h
@@ -8,6 +8,7 @@
 
 #include "sick_scan/tcp/BasicDatatypes.hpp"
 #include "sick_scan/tcp/tcp.hpp"
+#include <atomic>  // for std::atomic
 #include <map>  // for std::map
 
 //
@@ -58,6 +59,15 @@ public:
 
   /// Returns true if the tcp connection is established.
   bool isConnected();
+
+  /** \brief Marks the connection as lost, i.e. moves this object from the CONNECTED
+   * back into the CONSTRUCTED state.
+   *
+   * Called from the tcp read thread when the peer closed the connection or the socket
+   * read failed. Without this, m_state would remain CONNECTED forever and isConnected()
+   * could never report a lost connection.
+   */
+  void setDisconnected();
 
   /** \brief Closes the connection to the LMS. This is the opposite of init().
    *
@@ -127,7 +137,8 @@ protected:
     //		, RUNNING
   };
 
-  State m_state;
+  // Written by the tcp read thread (via setDisconnected), read by the driver threads.
+  std::atomic<State> m_state;
 };
 
 /// Class that represents a message that was sent by a sensor. (Event message)

--- a/include/sick_scan/sick_scan_common_tcp.h
+++ b/include/sick_scan/sick_scan_common_tcp.h
@@ -130,6 +130,14 @@ namespace sick_scan_xd
 
     bool isConnected() { return m_nw.isConnected(); }
 
+    /** \brief Sends a sopas request without waiting for or consuming the reply.
+     *
+     * The reply is left in recvQueue for whoever is interested in it.
+     *
+     * \return ExitSuccess on success, ExitError otherwise.
+     */
+    int sendSopasRequestNoReply(const std::string& sopasCmd, bool cola_binary);
+
     // Queue<std::vector<unsigned char> > recvQueue;
     Queue<DatagramWithTimeStamp> recvQueue;
     UINT32 m_alreadyReceivedBytes;

--- a/include/sick_scan/template_queue.h
+++ b/include/sick_scan/template_queue.h
@@ -60,6 +60,27 @@ public:
     return item;
   }
 
+  /*!
+  \brief Pop a matching entry if there is one, without ever blocking.
+  \return true if an entry was popped into item, false if the queue holds no match.
+
+  Use this instead of pop() whenever more than one thread consumes the queue: with two
+  consumers, a waitForIncomingObject()/pop() pair can race - the other thread takes the
+  entry in between and the blocking pop() then waits forever, ignoring any stop flag.
+  */
+  bool tryPop(const std::vector<std::string>& datagram_keywords, T& item)
+  {
+    std::unique_lock<std::mutex> mlock(mutex_);
+    typename std::list<T>::iterator datagram_found;
+    if (findFirstByKeyword(datagram_keywords, datagram_found) == false)
+    {
+      return false;
+    }
+    item = *datagram_found;
+    queue_.erase(datagram_found);
+    return true;
+  }
+
   void push(const T &item)
   {
     {

--- a/include/sick_scansegment_xd/config.h
+++ b/include/sick_scansegment_xd/config.h
@@ -169,6 +169,7 @@ namespace sick_scansegment_xd
         std::string user_level_password = "F4724744";  // Default password for client authorization
         bool listen_only_mode = false;             // Flag to activate "listen only mode"
         bool activate_lidoutputstate;                // Activate "LIDoutputstate" telegrams (safety I/O field monitoring) and publish sick_scan_msg::LIDoutputstateMsg on topic "lidoutputstate", default: false
+        int lidoutputstate_period_ms;                // Interval in ms at which the output state is re-read with "sRN LIDoutputstate"; 0: no cyclic polling; the state is still read once per connection and the topic is then only written when an output changes
         bool disable_udp_scandata;                    // True: skip udp scan data reception entirely, i.e. no udp socket timeout/reconnect handling (e.g. lidar does not send scan data over udp), default: false
         // MSR100 filter settings
         bool host_read_filtersettings;             // True  // Read multiScan136 settings for FREchoFilter, LFPangleRangeFilter and LFPlayerFilter at startup, default: true

--- a/include/sick_scansegment_xd/config.h
+++ b/include/sick_scansegment_xd/config.h
@@ -168,6 +168,8 @@ namespace sick_scansegment_xd
         int user_level = 3;                         // Default User Level (for picoScan, multiScan: 4)
         std::string user_level_password = "F4724744";  // Default password for client authorization
         bool listen_only_mode = false;             // Flag to activate "listen only mode"
+        bool activate_lidoutputstate;                // Activate "LIDoutputstate" telegrams (safety I/O field monitoring) and publish sick_scan_msg::LIDoutputstateMsg on topic "lidoutputstate", default: false
+        bool disable_udp_scandata;                    // True: skip udp scan data reception entirely, i.e. no udp socket timeout/reconnect handling (e.g. lidar does not send scan data over udp), default: false
         // MSR100 filter settings
         bool host_read_filtersettings;             // True  // Read multiScan136 settings for FREchoFilter, LFPangleRangeFilter and LFPlayerFilter at startup, default: true
         int host_FREchoFilter;                     // 1     // Optionally set FREchoFilter with 0 for FIRST_ECHO (EchoCount=1), 1 for ALL_ECHOS (EchoCount=3), or 2 for LAST_ECHO (EchoCount=1)

--- a/launch/sick_picoscan.launch
+++ b/launch/sick_picoscan.launch
@@ -15,6 +15,7 @@
     <arg name="imu_udp_port" default="7503"/>                                       <!-- udp port for picoScan imu data (if imu_enable is true) -->
     <arg name="listen_only_mode" default="False" />                                   <!-- flag to active listen only mode. If true TCP SOPAS initialization is skipped -->
     <arg name="activate_lidoutputstate" default="False" />                            <!-- activate LIDoutputstate telegrams (safety I/O field monitoring output state) and publish topic "lidoutputstate" -->
+    <arg name="lidoutputstate_period_ms" default="0" />                                <!-- interval in ms at which the output state is re-read with "sRN LIDoutputstate"; 0: no cyclic polling; the state is still read once per connection and the topic is then only written when an output changes -->
     <arg name="disable_udp_scandata" default="False" />                               <!-- True: skip udp scan data reception entirely (no udp timeout/reconnect handling), use when the lidar does not send scan data over udp -->
     <arg name="add_transform_xyz_rpy" default="0,0,0,0,0,0"/>
     <arg name="scandataformat" default="2"/>                  <!-- ScanDataFormat: 1 for msgpack or 2 for compact scandata, default: 2 -->
@@ -82,6 +83,7 @@
         <param name="user_level" type="int" value="4" />                                    <!-- Default user level for authorization (3: client, 4: service) -->
         <param name="user_level_password" type="string" value="81BE23AA" />                 <!-- Default user level password (for "client" (level 3): F4724744, for "service" (level 4): 81BE23AA) -->
         <param name="activate_lidoutputstate" type="bool" value="$(arg activate_lidoutputstate)" />  <!-- activate LIDoutputstate telegrams (safety I/O field monitoring output state) and publish topic "lidoutputstate", default: false -->
+        <param name="lidoutputstate_period_ms" type="int" value="$(arg lidoutputstate_period_ms)" />  <!-- interval in ms at which the output state is re-read, refreshing topic "lidoutputstate", 0 for no cyclic polling (state still read once per connection), default: 0 -->
         <param name="disable_udp_scandata" type="bool" value="$(arg disable_udp_scandata)" />  <!-- True: skip udp scan data reception entirely (no udp timeout/reconnect handling), default: false -->
         
         <!-- picoScan150 filter settings -->

--- a/launch/sick_picoscan.launch
+++ b/launch/sick_picoscan.launch
@@ -14,6 +14,8 @@
     <arg name="udp_port" default="2115" />                                          <!-- default udp port for picoScan devices is 2115 -->
     <arg name="imu_udp_port" default="7503"/>                                       <!-- udp port for picoScan imu data (if imu_enable is true) -->
     <arg name="listen_only_mode" default="False" />                                   <!-- flag to active listen only mode. If true TCP SOPAS initialization is skipped -->
+    <arg name="activate_lidoutputstate" default="False" />                            <!-- activate LIDoutputstate telegrams (safety I/O field monitoring output state) and publish topic "lidoutputstate" -->
+    <arg name="disable_udp_scandata" default="False" />                               <!-- True: skip udp scan data reception entirely (no udp timeout/reconnect handling), use when the lidar does not send scan data over udp -->
     <arg name="add_transform_xyz_rpy" default="0,0,0,0,0,0"/>
     <arg name="scandataformat" default="2"/>                  <!-- ScanDataFormat: 1 for msgpack or 2 for compact scandata, default: 2 -->
     <arg name="performanceprofilenumber" default="-1"/>       <!-- Set performance profile by "sWN PerformanceProfileNumber" if performanceprofilenumber >= 0 (for picoScan: 1-10), default: -1 -->
@@ -79,6 +81,8 @@
         <param name="sopas_timeout_ms" type="int" value="5000" />                           <!-- Timeout for SOPAS response in milliseconds, default: 5000 -->
         <param name="user_level" type="int" value="4" />                                    <!-- Default user level for authorization (3: client, 4: service) -->
         <param name="user_level_password" type="string" value="81BE23AA" />                 <!-- Default user level password (for "client" (level 3): F4724744, for "service" (level 4): 81BE23AA) -->
+        <param name="activate_lidoutputstate" type="bool" value="$(arg activate_lidoutputstate)" />  <!-- activate LIDoutputstate telegrams (safety I/O field monitoring output state) and publish topic "lidoutputstate", default: false -->
+        <param name="disable_udp_scandata" type="bool" value="$(arg disable_udp_scandata)" />  <!-- True: skip udp scan data reception entirely (no udp timeout/reconnect handling), default: false -->
         
         <!-- picoScan150 filter settings -->
         <param name="host_read_filtersettings" type="bool" value="True" />                                    <!-- Read picoScan150 settings for FREchoFilter, LFPangleRangeFilter and LFPlayerFilter at startup, default: true -->


### PR DESCRIPTION
Make LIDoutputstate usable as a safety input, where outputs are reported by
event only and silence is indistinguishable from a dead lidar.

Add lidoutputstate_period_ms: the state is read once per connection, and
cyclically when > 0. Readings are published on arrival and latched; an empty
output_state is published when the connection drops.

Fixes found on the way:
- tcp connection loss was never reported: disconnectFunction was empty, read
  errors did not notify, and there was no keepalive
- "not used" outputs were dropped from output_state, shifting every following
  output down and silently remapping the array index
- telegrams carrying no output state were published as valid
- sEA/sFA datagrams were parsed as output states, and a blocking pop could
  wedge the worker with two consumers on the queue
- failed LIDoutputstate activation was non-fatal, leaving the node silent
- the receive-buffer overflow warning was commented out

BREAKING CHANGE: output_state now includes outputs reported as "not used"
(state 2), so its index is the physical output number.